### PR TITLE
Fix links formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 # Intel(R) Threading Building Blocks 2017 Update 5
-[![Stable release](https://img.shields.io/badge/version-2017_U5-green.svg)] (https://github.com/01org/tbb/releases/tag/2017_U5)
+[![Stable release](https://img.shields.io/badge/version-2017_U5-green.svg)](https://github.com/01org/tbb/releases/tag/2017_U5)
 [![Apache License Version 2.0](https://img.shields.io/badge/license-Apache_2.0-green.svg)](LICENSE)
 
 Intel(R) Threading Building Blocks (Intel(R) TBB) lets you easily write parallel C++ programs that take
 full advantage of multicore performance, that are portable, composable and have future-proof scalability.
 
 ## Release Information
-Here are the latest [Changes] (CHANGES) and [Release Notes]
-(doc/Release_Notes.txt) (contains system requirements and known issues).
+Here are the latest [Changes](CHANGES) and [Release Notes](doc/Release_Notes.txt) (contains system requirements and known issues).
 
 ## Documentation
-* Intel(R) TBB [tutorial] (https://software.intel.com/en-us/tbb-tutorial)
-* Intel(R) TBB general documentation: [stable] (https://software.intel.com/en-us/tbb-documentation)
-and [latest] (https://www.threadingbuildingblocks.org/docs/help/index.htm)
+* Intel(R) TBB [tutorial](https://software.intel.com/en-us/tbb-tutorial)
+* Intel(R) TBB general documentation: [stable](https://software.intel.com/en-us/tbb-documentation)
+and [latest](https://www.threadingbuildingblocks.org/docs/help/index.htm)
 
 ## Support
 Please report issues and suggestions via
@@ -20,10 +19,10 @@ Please report issues and suggestions via
 [Intel(R) TBB forum](http://software.intel.com/en-us/forums/intel-threading-building-blocks/).
 
 ## How to Contribute
-Please, read the instructions on the official [Intel(R) TBB open source site] (https://www.threadingbuildingblocks.org/submit-contribution).
+Please, read the instructions on the official [Intel(R) TBB open source site](https://www.threadingbuildingblocks.org/submit-contribution).
 
 ## Engineering team contacts
-* [E-mail us.] (mailto:inteltbbdevelopers@intel.com)
+* [E-mail us.](mailto:inteltbbdevelopers@intel.com)
 
 ------------------------------------------------------------------------
 Intel and the Intel logo are trademarks of Intel Corporation or its subsidiaries in the U.S. and/or other countries.


### PR DESCRIPTION
With new Markdown render, there no space between `[]` and `()` for links is allowed.