### PR TITLE
Changed handling of size == 0 in scalable_aligned_malloc

### DIFF
--- a/src/tbbmalloc/frontend.cpp
+++ b/src/tbbmalloc/frontend.cpp
@@ -3019,10 +3019,11 @@ extern "C" int scalable_posix_memalign(void **memptr, size_t alignment, size_t s
 
 extern "C" void * scalable_aligned_malloc(size_t size, size_t alignment)
 {
-    if (!isPowerOfTwo(alignment) || 0==size) {
+    if (!isPowerOfTwo(alignment)) {
         errno = EINVAL;
         return NULL;
     }
+    if (!size) size = sizeof(size_t);
     void *tmp = allocateAligned(defaultMemPool, size, alignment);
     if (!tmp) errno = ENOMEM;
     return tmp;


### PR DESCRIPTION
I modified scalable_aligned_malloc to be consistent with scalable_malloc and allocate sizeof(size_t) bytes when the requested size is 0. The same can obviously be achieved in the calling code, but I thought it might be a good idea to have both functions behave the same.