### PR TITLE
ENH: Provide fine grained version detail for CMake find_package

### DIFF
--- a/cmake/README.rst
+++ b/cmake/README.rst
@@ -30,7 +30,7 @@ Visit our `forum <https://software.intel.com/en-us/forums/intel-threading-buildi
 Release Notes
 -------------
 * Minimum supported CMake version: ``3.0.0``.
-* Intel TBB versioning via `find_package <https://cmake.org/cmake/help/latest/command/find_package.html>`_ has restricted functionality: compatibility of update numbers (as well as interface versions) is not checked. Supported versioning: ``find_package(TBB <major>.<minor> ...)``. Intel TBB interface version can be obtained in the customer project via the ``TBB_INTERFACE_VERSION`` variable.
+* Intel TBB versioning via `find_package <https://cmake.org/cmake/help/latest/command/find_package.html>`_ has restricted functionality: compatibility of update numbers (as well as interface versions) is not checked. Supported versioning: ``find_package(TBB <major>.<minor>[<.interface>] ...)``. Intel TBB interface version can be obtained in the customer project via the ``TBB_INTERFACE_VERSION`` variable.
 
 Use cases of Intel TBB integration into CMake-aware projects
 ------------------------------------------------------------

--- a/cmake/TBBMakeConfig.cmake
+++ b/cmake/TBBMakeConfig.cmake
@@ -155,7 +155,7 @@ endif()")
     string(REGEX REPLACE ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1" _tbb_ver_major "${_tbb_stddef}")
     string(REGEX REPLACE ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1" _tbb_ver_minor "${_tbb_stddef}")
     string(REGEX REPLACE ".*#define TBB_INTERFACE_VERSION ([0-9]+).*" "\\1" TBB_INTERFACE_VERSION "${_tbb_stddef}")
-    set(TBB_VERSION "${_tbb_ver_major}.${_tbb_ver_minor}")
+    set(TBB_VERSION "${_tbb_ver_major}.${_tbb_ver_minor}.${TBB_INTERFACE_VERSION}")
 
     if (tbb_MK_CONFIG_FOR_SOURCE)
         set(_tbb_config_template TBBConfigForSource.cmake.in)


### PR DESCRIPTION
Bug fixes to the interface often need to be accounted for when
finding a TBB package.  Add the interface details as a
patch to the versioning.