### PR TITLE
Use nanosleep on Linux in atomic_backoff when spinning for a long time.

### DIFF
--- a/include/tbb/machine/linux_common.h
+++ b/include/tbb/machine/linux_common.h
@@ -25,6 +25,9 @@
 #include <sched.h>
 #define __TBB_Yield()  sched_yield()
 
+#include <time.h>
+#define __TBB_LongYield()  { struct ::timespec __ts = {}; ::nanosleep(&__ts, 0); }
+
 #include <unistd.h>
 /* Futex definitions */
 #include <sys/syscall.h>


### PR DESCRIPTION
This allows to significantly reduce CPU system time while spinning, as
apparently nanosleep deschedules the thread for a longer time.

See https://github.com/01org/tbb/issues/105. On the test presented there,
this patch offers to reduce CPU system time by 25-30%. On a real world
application that test is based on this patch offers ~10% improvement.

However, the change causes test_task_arena failures, as described in
https://github.com/01org/tbb/issues/104.