### PR TITLE
 CMake: add module TBBInstallConfig

### DIFF
--- a/cmake/README.rst
+++ b/cmake/README.rst
@@ -210,6 +210,78 @@ Variables set during Intel TBB configuration:
 ``TBB_INTERFACE_VERSION``  Intel TBB interface version
 =========================  ================================================
 
+TBBInstallConfig
+^^^^^^^^^^^^^^^^
+
+Module for generation and installation of TBB CMake configuration files (TBBConfig.cmake and TBBConfigVersion.cmake files) on Linux and macOS.
+
+Provides the following functions:
+
+ .. code:: cmake
+
+  tbb_install_config(INSTALL_DIR <install_dir> SYSTEM_NAME Linux|Darwin
+                     [TBB_VERSION <major>.<minor>.<interface>|TBB_VERSION_FILE <version_file>]
+                     [LIB_REL_PATH <lib_rel_path> INC_REL_PATH <inc_rel_path>]
+                     [LIB_PATH <lib_path> INC_PATH <inc_path>])``
+
+**Note: the module overwrites existing TBBConfig.cmake and TBBConfigVersion.cmake files in <install_dir>.**
+
+``tbb_config_installer.cmake`` allows to run ``TBBInstallConfig.cmake`` from command line.
+It accepts the same parameters as ``tbb_install_config`` function, run ``cmake -P tbb_config_installer.cmake`` to get help.
+
+Use cases
+"""""""""
+**Prepare TBB CMake configuration files for custom TBB package.**
+
+The use case is applicable for package maintainers who create own TBB packages and want to create TBBConfig.cmake and TBBConfigVersion.cmake for these packages.
+
+===========================================  ===========================================================
+              Parameter                                      Description
+===========================================  ===========================================================
+``TBB_VERSION_FILE <version_file>``          Path to ``tbb_stddef.h`` to parse version from and
+                                             write it to TBBConfigVersion.cmake
+``TBB_VERSION <major>.<minor>.<interface>``  Directly specified TBB version;
+                                             alternative to ``TBB_VERSION_FILE`` parameter
+``LIB_REL_PATH <lib_rel_path>``              Relative path to TBB binaries, default: ``../..``
+``INC_REL_PATH <inc_rel_path>``              Relative path to TBB headers, default: ``../../../include``
+===========================================  ===========================================================
+
+*Example*
+
+ Assume your package is installed to the following structure:
+
+ * Binaries go to ``<prefix>/lib``
+ * Headers go to ``<prefix>/include``
+ * CMake configuration files go to ``<prefix>/lib/cmake/<package>``
+
+ The package is packed from ``/my/package/content`` directory.
+
+ ``cmake -DINSTALL_DIR=/my/package/content/lib/cmake/TBB -DTBB_VERSION=/my/package/content/include/tbb/tbb_stddef.h -P tbb_config_installer.cmake`` (default relative paths will be used)
+
+**Install TBB CMake configuration files for installed TBB.**
+
+The use case is applicable for users who have installed TBB, but do not have (or have incorrect) CMake configuration files for this TBB.
+
+============================  ==============================================
+      Parameter                            Description
+============================  ==============================================
+``INSTALL_DIR <directory>``   Directory to install CMake configuration files
+``SYSTEM_NAME Linux|Darwin``  OS name to generate config files for
+``LIB_PATH <lib_path>``       Path to installed TBB binaries
+``INC_PATH <inc_path>``       Path to installed TBB headers
+============================  ==============================================
+
+``LIB_PATH`` and ``INC_PATH`` will be converted to relative paths based on ``INSTALL_DIR``.
+By default TBB version will be parsed from ``<inc_path>/tbb/tbb_stddef.h``,
+but it can be overridden by optional parameters ``TBB_VERSION_FILE`` or ``TBB_VERSION``.
+
+*Example*
+
+ TBB is installed to ``/usr`` directory.
+ In order to create TBBConfig.cmake and TBBConfigVersion.cmake in ``/usr/lib/cmake/TBB`` run
+
+ ``cmake -DINSTALL_DIR=/usr/lib/cmake/TBB -DLIB_PATH=/usr/lib -DINC_PATH=/usr/include -P tbb_config_installer.cmake``.
+
 TBBGet
 ^^^^^^
 
@@ -234,7 +306,7 @@ Provides the following functions:
 TBBMakeConfig
 ^^^^^^^^^^^^^
 
-Module for making TBBConfig in ``Intel(R) Threading Building Blocks (Intel(R) TBB)`` binary package.
+Module for making TBBConfig in `official TBB binary packages published on GitHub <https://github.com/01org/tbb/releases>`_.
 
 This module is to be used for packages that do not have TBBConfig.
 

--- a/cmake/README.rst
+++ b/cmake/README.rst
@@ -238,6 +238,8 @@ The use case is applicable for package maintainers who create own TBB packages a
 ===========================================  ===========================================================
               Parameter                                      Description
 ===========================================  ===========================================================
+``INSTALL_DIR <directory>``                  Directory to install CMake configuration files
+``SYSTEM_NAME Linux|Darwin``                 OS name to generate config files for
 ``TBB_VERSION_FILE <version_file>``          Path to ``tbb_stddef.h`` to parse version from and
                                              write it to TBBConfigVersion.cmake
 ``TBB_VERSION <major>.<minor>.<interface>``  Directly specified TBB version;

--- a/cmake/README.rst
+++ b/cmake/README.rst
@@ -256,7 +256,7 @@ The use case is applicable for package maintainers who create own TBB packages a
 
  The package is packed from ``/my/package/content`` directory.
 
- ``cmake -DINSTALL_DIR=/my/package/content/lib/cmake/TBB -DTBB_VERSION=/my/package/content/include/tbb/tbb_stddef.h -P tbb_config_installer.cmake`` (default relative paths will be used)
+ ``cmake -DINSTALL_DIR=/my/package/content/lib/cmake/TBB -DSYSTEM_NAME=Linux -DTBB_VERSION_FILE=/my/package/content/include/tbb/tbb_stddef.h -P tbb_config_installer.cmake`` (default relative paths will be used)
 
 **Install TBB CMake configuration files for installed TBB.**
 
@@ -280,7 +280,7 @@ but it can be overridden by optional parameters ``TBB_VERSION_FILE`` or ``TBB_VE
  TBB is installed to ``/usr`` directory.
  In order to create TBBConfig.cmake and TBBConfigVersion.cmake in ``/usr/lib/cmake/TBB`` run
 
- ``cmake -DINSTALL_DIR=/usr/lib/cmake/TBB -DLIB_PATH=/usr/lib -DINC_PATH=/usr/include -P tbb_config_installer.cmake``.
+ ``cmake -DINSTALL_DIR=/usr/lib/cmake/TBB -DSYSTEM_NAME=Linux -DLIB_PATH=/usr/lib -DINC_PATH=/usr/include -P tbb_config_installer.cmake``.
 
 TBBGet
 ^^^^^^

--- a/cmake/TBBInstallConfig.cmake
+++ b/cmake/TBBInstallConfig.cmake
@@ -1,0 +1,97 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+#
+
+include(CMakeParseArguments)
+
+# Save the location of Intel TBB CMake modules here, as it will not be possible to do inside functions,
+# see for details: https://cmake.org/cmake/help/latest/variable/CMAKE_CURRENT_LIST_DIR.html
+set(_tbb_cmake_module_path ${CMAKE_CURRENT_LIST_DIR})
+
+function(tbb_install_config)
+    set(oneValueArgs INSTALL_DIR
+                     SYSTEM_NAME
+                     LIB_REL_PATH INC_REL_PATH TBB_VERSION TBB_VERSION_FILE
+                     LIB_PATH INC_PATH)                                      # If TBB is installed on the system
+
+    cmake_parse_arguments(tbb_IC "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    get_filename_component(config_install_dir ${tbb_IC_INSTALL_DIR} ABSOLUTE)
+
+    # --- TBB_LIB_REL_PATH handling ---
+    set(TBB_LIB_REL_PATH "../..")
+
+    if (tbb_IC_LIB_REL_PATH)
+        set(TBB_LIB_REL_PATH ${tbb_IC_LIB_REL_PATH})
+    endif()
+
+    if (tbb_IC_LIB_PATH)
+        get_filename_component(lib_abs_path ${tbb_IC_LIB_PATH} ABSOLUTE)
+        file(RELATIVE_PATH TBB_LIB_REL_PATH ${config_install_dir} ${lib_abs_path})
+        unset(lib_abs_path)
+    endif()
+    # ------
+
+    # --- TBB_INC_REL_PATH handling ---
+    set(TBB_INC_REL_PATH "../../../include")
+
+    if (tbb_IC_INC_REL_PATH)
+        set(TBB_INC_REL_PATH ${tbb_IC_INC_REL_PATH})
+    endif()
+
+    if (tbb_IC_INC_PATH)
+        get_filename_component(inc_abs_path ${tbb_IC_INC_PATH} ABSOLUTE)
+        file(RELATIVE_PATH TBB_INC_REL_PATH ${config_install_dir} ${inc_abs_path})
+        unset(inc_abs_path)
+    endif()
+    # ------
+
+    # --- TBB_VERSION handling ---
+    if (tbb_IC_TBB_VERSION)
+        set(TBB_VERSION ${tbb_IC_TBB_VERSION})
+    else()
+        set(tbb_version_file "${config_install_dir}/${TBB_INC_REL_PATH}/tbb/tbb_stddef.h")
+        if (tbb_IC_TBB_VERSION_FILE)
+            set(tbb_version_file ${tbb_IC_TBB_VERSION_FILE})
+        endif()
+
+        file(READ ${tbb_version_file} _tbb_stddef)
+        string(REGEX REPLACE ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1" _tbb_ver_major "${_tbb_stddef}")
+        string(REGEX REPLACE ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1" _tbb_ver_minor "${_tbb_stddef}")
+        string(REGEX REPLACE ".*#define TBB_INTERFACE_VERSION ([0-9]+).*" "\\1" _tbb_ver_interface "${_tbb_stddef}")
+        set(TBB_VERSION "${_tbb_ver_major}.${_tbb_ver_minor}.${_tbb_ver_interface}")
+    endif()
+    # ------
+
+    set(tbb_system_name ${CMAKE_SYSTEM_NAME})
+    if (tbb_IC_SYSTEM_NAME)
+        set(tbb_system_name ${tbb_IC_SYSTEM_NAME})
+    endif()
+
+    if (tbb_system_name STREQUAL "Linux")
+        set(TBB_LIB_PREFIX "lib")
+        set(TBB_LIB_EXT "so.2")
+    elseif (tbb_system_name STREQUAL "Darwin")
+        set(TBB_LIB_PREFIX "lib")
+        set(TBB_LIB_EXT "dylib")
+    else()
+        message(FATAL_ERROR "Unsupported OS name: ${tbb_system_name}")
+    endif()
+
+    configure_file(${_tbb_cmake_module_path}/templates/TBBConfig.cmake.in ${config_install_dir}/TBBConfig.cmake @ONLY)
+    configure_file(${_tbb_cmake_module_path}/templates/TBBConfigVersion.cmake.in ${config_install_dir}/TBBConfigVersion.cmake @ONLY)
+endfunction()

--- a/cmake/TBBInstallConfig.cmake
+++ b/cmake/TBBInstallConfig.cmake
@@ -31,6 +31,7 @@ function(tbb_install_config)
     cmake_parse_arguments(tbb_IC "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     get_filename_component(config_install_dir ${tbb_IC_INSTALL_DIR} ABSOLUTE)
+    file(MAKE_DIRECTORY ${config_install_dir})
 
     # --- TBB_LIB_REL_PATH handling ---
     set(TBB_LIB_REL_PATH "../..")

--- a/cmake/TBBMakeConfig.cmake
+++ b/cmake/TBBMakeConfig.cmake
@@ -162,7 +162,7 @@ endif()")
     else()
         set(_tbb_config_template TBBConfig.cmake.in)
     endif()
-    configure_file(${_tbb_cmake_module_path}/templates/${_tbb_config_template}   ${tbb_config_dir}/TBBConfig.cmake @ONLY)
+    configure_file(${_tbb_cmake_module_path}/templates/${_tbb_config_template}   ${tbb_config_dir}/TBBConfigInternal.cmake @ONLY)
     configure_file(${_tbb_cmake_module_path}/templates/TBBConfigVersion.cmake.in ${tbb_config_dir}/TBBConfigVersion.cmake @ONLY)
 
     set(${tbb_MK_CONFIG_DIR} ${tbb_config_dir} PARENT_SCOPE)

--- a/cmake/demo/TBBConfig.cmake
+++ b/cmake/demo/TBBConfig.cmake
@@ -1,0 +1,76 @@
+# Copyright (c) 2017-2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+#
+
+# TBB_FOUND should not be set explicitly. It is defined automatically by CMake.
+# Handling of TBB_VERSION is in TBBConfigVersion.cmake.
+
+if (NOT TBB_FIND_COMPONENTS)
+    set(TBB_FIND_COMPONENTS "tbb tbbmalloc tbbmalloc_proxy")
+    foreach (_tbb_component ${TBB_FIND_COMPONENTS})
+        set(TBB_FIND_REQUIRED_${_tbb_component} 1)
+    endforeach()
+endif()
+
+# Add components with internal dependencies: tbbmalloc_proxy -> tbbmalloc
+list(FIND TBB_FIND_COMPONENTS tbbmalloc_proxy _tbbmalloc_proxy_ix)
+if (NOT _tbbmalloc_proxy_ix EQUAL -1)
+    list(FIND TBB_FIND_COMPONENTS tbbmalloc _tbbmalloc_ix)
+    if (_tbbmalloc_ix EQUAL -1)
+        list(APPEND TBB_FIND_COMPONENTS tbbmalloc)
+        set(TBB_FIND_REQUIRED_tbbmalloc ${TBB_FIND_REQUIRED_tbbmalloc_proxy})
+    endif()
+    unset(_tbbmalloc_ix)
+endif()
+unset(_tbbmalloc_proxy_ix)
+
+foreach (_tbb_component ${TBB_FIND_COMPONENTS})
+    set(_tbb_release_lib "${CMAKE_CURRENT_LIST_FILE}/../../lib${_tbb_component}.so.2")
+    set(_tbb_debug_lib "${CMAKE_CURRENT_LIST_FILE}/../../lib${_tbb_component}_debug.so.2")
+
+    if (EXISTS "${_tbb_release_lib}" OR EXISTS "${_tbb_debug_lib}")
+        add_library(TBB::${_tbb_component} SHARED IMPORTED)
+        set_target_properties(TBB::${_tbb_component} PROPERTIES
+                              INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_FILE}/../../../include")
+
+        if (EXISTS "${_tbb_release_lib}")
+            set_target_properties(TBB::${_tbb_component} PROPERTIES
+                                  IMPORTED_LOCATION_RELEASE "${_tbb_release_lib}")
+            set_property(TARGET TBB::${_tbb_component} APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+        endif()
+
+        if (EXISTS "${_tbb_debug_lib}")
+            set_target_properties(TBB::${_tbb_component} PROPERTIES
+                                  IMPORTED_LOCATION_DEBUG "${_tbb_debug_lib}")
+            set_property(TARGET TBB::${_tbb_component} APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+        endif()
+
+        # Add internal dependencies for imported targets: TBB::tbbmalloc_proxy -> TBB::tbbmalloc
+        if (_tbb_component STREQUAL tbbmalloc_proxy)
+            set_target_properties(TBB::tbbmalloc_proxy PROPERTIES INTERFACE_LINK_LIBRARIES TBB::tbbmalloc)
+        endif()
+
+        list(APPEND TBB_IMPORTED_TARGETS TBB::${_tbb_component})
+        set(TBB_${_tbb_component}_FOUND 1)
+    elseif (TBB_FIND_REQUIRED AND TBB_FIND_REQUIRED_${_tbb_component})
+        message(STATUS "Missed required Intel TBB component: ${_tbb_component}")
+        set(TBB_FOUND FALSE)
+        set(TBB_${_tbb_component}_FOUND 0)
+    endif()
+endforeach()
+unset(_tbb_release_lib)
+unset(_tbb_debug_lib)

--- a/cmake/demo/TBBConfig.cmake
+++ b/cmake/demo/TBBConfig.cmake
@@ -20,7 +20,7 @@
 # Handling of TBB_VERSION is in TBBConfigVersion.cmake.
 
 if (NOT TBB_FIND_COMPONENTS)
-    set(TBB_FIND_COMPONENTS "tbb tbbmalloc tbbmalloc_proxy")
+    set(TBB_FIND_COMPONENTS "tbb;tbbmalloc;tbbmalloc_proxy")
     foreach (_tbb_component ${TBB_FIND_COMPONENTS})
         set(TBB_FIND_REQUIRED_${_tbb_component} 1)
     endforeach()
@@ -39,13 +39,13 @@ endif()
 unset(_tbbmalloc_proxy_ix)
 
 foreach (_tbb_component ${TBB_FIND_COMPONENTS})
-    set(_tbb_release_lib "${CMAKE_CURRENT_LIST_FILE}/../../lib${_tbb_component}.so.2")
-    set(_tbb_debug_lib "${CMAKE_CURRENT_LIST_FILE}/../../lib${_tbb_component}_debug.so.2")
+    set(_tbb_release_lib "${CMAKE_CURRENT_LIST_DIR}/../../lib${_tbb_component}.so.2")
+    set(_tbb_debug_lib "${CMAKE_CURRENT_LIST_DIR}/../../lib${_tbb_component}_debug.so.2")
 
     if (EXISTS "${_tbb_release_lib}" OR EXISTS "${_tbb_debug_lib}")
         add_library(TBB::${_tbb_component} SHARED IMPORTED)
         set_target_properties(TBB::${_tbb_component} PROPERTIES
-                              INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_FILE}/../../../include")
+                              INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/../../../include")
 
         if (EXISTS "${_tbb_release_lib}")
             set_target_properties(TBB::${_tbb_component} PROPERTIES
@@ -68,6 +68,7 @@ foreach (_tbb_component ${TBB_FIND_COMPONENTS})
         set(TBB_${_tbb_component}_FOUND 1)
     elseif (TBB_FIND_REQUIRED AND TBB_FIND_REQUIRED_${_tbb_component})
         message(STATUS "Missed required Intel TBB component: ${_tbb_component}")
+        message(STATUS "  one or both of:\n   ${_tbb_release_lib}\n    ${_tbb_debug_lib}\n   files must exist.")
         set(TBB_FOUND FALSE)
         set(TBB_${_tbb_component}_FOUND 0)
     endif()

--- a/cmake/demo/TBBConfigVersion.cmake
+++ b/cmake/demo/TBBConfigVersion.cmake
@@ -1,0 +1,28 @@
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+#
+
+set(PACKAGE_VERSION 2019.0.11003)
+
+if ("${PACKAGE_VERSION}" VERSION_LESS "${PACKAGE_FIND_VERSION}")
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    if ("${PACKAGE_VERSION}" VERSION_EQUAL "${PACKAGE_FIND_VERSION}")
+        set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+endif()

--- a/cmake/tbb_config_installer.cmake
+++ b/cmake/tbb_config_installer.cmake
@@ -1,0 +1,50 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+#
+
+function(tbb_conf_gen_print_help)
+    message("Usage: cmake -DINSTALL_DIR=<config_install_dir> -DSYSTEM_NAME=Linux|Darwin <parameters> -P tbb_config_generator.cmake
+
+Parameters:
+  For custom TBB package:
+    -DTBB_VERSION_FILE=<tbb_version_file>
+    -DTBB_VERSION=<major>.<minor>.<interface> (alternative to TBB_VERSION_FILE)
+    -DLIB_REL_PATH=<relative_path_to_tbb_binaries>
+    -DINC_REL_PATH=<relative_path_to_tbb_headers>
+  For installed TBB:
+    -DLIB_PATH=<path_to_installed_tbb_binaries>
+    -DINC_PATH=<path_to_installed_tbb_headers>
+")
+endfunction()
+
+if (NOT DEFINED INSTALL_DIR)
+    tbb_conf_gen_print_help()
+    message(FATAL_ERROR "Required parameter INSTALL_DIR is not defined")
+endif()
+
+if (NOT DEFINED SYSTEM_NAME)
+    tbb_conf_gen_print_help()
+    message(FATAL_ERROR "Required parameter SYSTEM_NAME is not defined")
+endif()
+
+foreach (arg TBB_VERSION LIB_REL_PATH INC_REL_PATH TBB_VERSION_FILE LIB_PATH INC_PATH)
+    set(optional_args ${optional_args} ${arg} ${${arg}})
+endforeach()
+
+include(${CMAKE_CURRENT_LIST_DIR}/TBBInstallConfig.cmake)
+tbb_install_config(INSTALL_DIR ${INSTALL_DIR} SYSTEM_NAME ${SYSTEM_NAME} ${optional_args})
+message(STATUS "TBBConfig files were created in ${INSTALL_DIR}")

--- a/cmake/templates/TBBConfig.cmake.in
+++ b/cmake/templates/TBBConfig.cmake.in
@@ -16,7 +16,26 @@
 #
 #
 
-# TBB_FOUND should not be set explicitly. It is defined automatically by CMake.
+# It defines the following variables:
+#     TBB_tbb_FOUND
+#     TBB_tbbmalloc_FOUND
+#     TBB_tbbmalloc_proxy_FOUND
+#     TBB_IMPORTED_TARGETS
+#
+# Initialize to default values
+if (NOT TBB_tbb_FOUND)
+    set(TBB_tbb_FOUND 0)
+endif()
+if (NOT TBB_tbbmalloc_FOUND)
+    set(TBB_tbbmalloc_FOUND 0)
+endif()
+if (NOT TBB_tbbmalloc_proxy_FOUND)
+    set(TBB_tbbmalloc_proxy_FOUND 0)
+endif()
+if (NOT TBB_IMPORTED_TARGETS)
+    set(TBB_IMPORTED_TARGETS "")
+endif()
+
 # Handling of TBB_VERSION is in TBBConfigVersion.cmake.
 
 if (NOT TBB_FIND_COMPONENTS)
@@ -43,28 +62,31 @@ foreach (_tbb_component ${TBB_FIND_COMPONENTS})
     set(_tbb_debug_lib "${CMAKE_CURRENT_LIST_DIR}/@TBB_LIB_REL_PATH@/@TBB_LIB_PREFIX@${_tbb_component}_debug.@TBB_LIB_EXT@")
 
     if (EXISTS "${_tbb_release_lib}" OR EXISTS "${_tbb_debug_lib}")
-        add_library(TBB::${_tbb_component} SHARED IMPORTED)
-        set_target_properties(TBB::${_tbb_component} PROPERTIES
-                              INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/@TBB_INC_REL_PATH@")
-
-        if (EXISTS "${_tbb_release_lib}")
+        if (NOT TARGET TBB::${_tbb_component})
+            add_library(TBB::${_tbb_component} SHARED IMPORTED)
             set_target_properties(TBB::${_tbb_component} PROPERTIES
-                                  IMPORTED_LOCATION_RELEASE "${_tbb_release_lib}")
-            set_property(TARGET TBB::${_tbb_component} APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-        endif()
+                                  INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/@TBB_INC_REL_PATH@")
 
-        if (EXISTS "${_tbb_debug_lib}")
-            set_target_properties(TBB::${_tbb_component} PROPERTIES
-                                  IMPORTED_LOCATION_DEBUG "${_tbb_debug_lib}")
-            set_property(TARGET TBB::${_tbb_component} APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
-        endif()
+            if (EXISTS "${_tbb_release_lib}")
+                set_target_properties(TBB::${_tbb_component} PROPERTIES
+                                      IMPORTED_LOCATION_RELEASE "${_tbb_release_lib}")
+                set_property(TARGET TBB::${_tbb_component} APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+            endif()
 
-        # Add internal dependencies for imported targets: TBB::tbbmalloc_proxy -> TBB::tbbmalloc
-        if (_tbb_component STREQUAL tbbmalloc_proxy)
-            set_target_properties(TBB::tbbmalloc_proxy PROPERTIES INTERFACE_LINK_LIBRARIES TBB::tbbmalloc)
-        endif()
+            if (EXISTS "${_tbb_debug_lib}")
+                set_target_properties(TBB::${_tbb_component} PROPERTIES
+                                      IMPORTED_LOCATION_DEBUG "${_tbb_debug_lib}")
+                set_property(TARGET TBB::${_tbb_component} APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+            endif()
 
-        list(APPEND TBB_IMPORTED_TARGETS TBB::${_tbb_component})
+            # Add internal dependencies for imported targets: TBB::tbbmalloc_proxy -> TBB::tbbmalloc
+            if (_tbb_component STREQUAL tbbmalloc_proxy)
+                set_target_properties(TBB::tbbmalloc_proxy PROPERTIES INTERFACE_LINK_LIBRARIES TBB::tbbmalloc)
+            endif()
+            list(APPEND TBB_IMPORTED_TARGETS TBB::${_tbb_component})
+        else()
+            message(STATUS "Using previously found TBB::${_tbb_component}")
+        endif()
         set(TBB_${_tbb_component}_FOUND 1)
     elseif (TBB_FIND_REQUIRED AND TBB_FIND_REQUIRED_${_tbb_component})
         message(STATUS "Missed required Intel TBB component: ${_tbb_component}")

--- a/cmake/templates/TBBConfig.cmake.in
+++ b/cmake/templates/TBBConfig.cmake.in
@@ -20,7 +20,7 @@
 # Handling of TBB_VERSION is in TBBConfigVersion.cmake.
 
 if (NOT TBB_FIND_COMPONENTS)
-    set(TBB_FIND_COMPONENTS "tbb tbbmalloc tbbmalloc_proxy")
+    set(TBB_FIND_COMPONENTS "tbb;tbbmalloc;tbbmalloc_proxy")
     foreach (_tbb_component ${TBB_FIND_COMPONENTS})
         set(TBB_FIND_REQUIRED_${_tbb_component} 1)
     endforeach()
@@ -39,13 +39,13 @@ endif()
 unset(_tbbmalloc_proxy_ix)
 
 foreach (_tbb_component ${TBB_FIND_COMPONENTS})
-    set(_tbb_release_lib "${CMAKE_CURRENT_LIST_FILE}/@TBB_LIB_REL_PATH@/@TBB_LIB_PREFIX@${_tbb_component}.@TBB_LIB_EXT@")
-    set(_tbb_debug_lib "${CMAKE_CURRENT_LIST_FILE}/@TBB_LIB_REL_PATH@/@TBB_LIB_PREFIX@${_tbb_component}_debug.@TBB_LIB_EXT@")
+    set(_tbb_release_lib "${CMAKE_CURRENT_LIST_DIR}/@TBB_LIB_REL_PATH@/@TBB_LIB_PREFIX@${_tbb_component}.@TBB_LIB_EXT@")
+    set(_tbb_debug_lib "${CMAKE_CURRENT_LIST_DIR}/@TBB_LIB_REL_PATH@/@TBB_LIB_PREFIX@${_tbb_component}_debug.@TBB_LIB_EXT@")
 
     if (EXISTS "${_tbb_release_lib}" OR EXISTS "${_tbb_debug_lib}")
         add_library(TBB::${_tbb_component} SHARED IMPORTED)
         set_target_properties(TBB::${_tbb_component} PROPERTIES
-                              INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_FILE}/@TBB_INC_REL_PATH@")
+                              INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/@TBB_INC_REL_PATH@")
 
         if (EXISTS "${_tbb_release_lib}")
             set_target_properties(TBB::${_tbb_component} PROPERTIES
@@ -68,6 +68,7 @@ foreach (_tbb_component ${TBB_FIND_COMPONENTS})
         set(TBB_${_tbb_component}_FOUND 1)
     elseif (TBB_FIND_REQUIRED AND TBB_FIND_REQUIRED_${_tbb_component})
         message(STATUS "Missed required Intel TBB component: ${_tbb_component}")
+        message(STATUS "  one or both of:\n   ${_tbb_release_lib}\n    ${_tbb_debug_lib}\n   files must exist.")
         set(TBB_FOUND FALSE)
         set(TBB_${_tbb_component}_FOUND 0)
     endif()

--- a/cmake/templates/TBBConfigInternal.cmake.in
+++ b/cmake/templates/TBBConfigInternal.cmake.in
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 Intel Corporation
+# Copyright (c) 2017-2018 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 # Handling of TBB_VERSION is in TBBConfigVersion.cmake.
 
 if (NOT TBB_FIND_COMPONENTS)
-    set(TBB_FIND_COMPONENTS "tbb tbbmalloc tbbmalloc_proxy")
+    set(TBB_FIND_COMPONENTS "@TBB_DEFAULT_COMPONENTS@")
     foreach (_tbb_component ${TBB_FIND_COMPONENTS})
         set(TBB_FIND_REQUIRED_${_tbb_component} 1)
     endforeach()
@@ -34,30 +34,37 @@ if (NOT _tbbmalloc_proxy_ix EQUAL -1)
         list(APPEND TBB_FIND_COMPONENTS tbbmalloc)
         set(TBB_FIND_REQUIRED_tbbmalloc ${TBB_FIND_REQUIRED_tbbmalloc_proxy})
     endif()
-    unset(_tbbmalloc_ix)
 endif()
-unset(_tbbmalloc_proxy_ix)
+
+set(TBB_INTERFACE_VERSION @TBB_INTERFACE_VERSION@)
+
+get_filename_component(_tbb_root "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_tbb_root "${_tbb_root}" PATH)
+
+set(_tbb_x32_subdir @TBB_X32_SUBDIR@)
+set(_tbb_x64_subdir @TBB_X64_SUBDIR@)
+
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(_tbb_arch_subdir ${_tbb_x64_subdir})
+else()
+    set(_tbb_arch_subdir ${_tbb_x32_subdir})
+endif()
+
+@TBB_CHOOSE_COMPILER_SUBDIR@
+
+get_filename_component(_tbb_lib_path "${_tbb_root}/@TBB_SHARED_LIB_DIR@/${_tbb_arch_subdir}/${_tbb_compiler_subdir}" ABSOLUTE)
 
 foreach (_tbb_component ${TBB_FIND_COMPONENTS})
-    set(_tbb_release_lib "${CMAKE_CURRENT_LIST_FILE}/@TBB_LIB_REL_PATH@/@TBB_LIB_PREFIX@${_tbb_component}.@TBB_LIB_EXT@")
-    set(_tbb_debug_lib "${CMAKE_CURRENT_LIST_FILE}/@TBB_LIB_REL_PATH@/@TBB_LIB_PREFIX@${_tbb_component}_debug.@TBB_LIB_EXT@")
+    set(_tbb_release_lib "${_tbb_lib_path}/@TBB_LIB_PREFIX@${_tbb_component}.@TBB_LIB_EXT@")
+    set(_tbb_debug_lib "${_tbb_lib_path}/@TBB_LIB_PREFIX@${_tbb_component}_debug.@TBB_LIB_EXT@")
 
-    if (EXISTS "${_tbb_release_lib}" OR EXISTS "${_tbb_debug_lib}")
+    if (EXISTS "${_tbb_release_lib}" AND EXISTS "${_tbb_debug_lib}")
         add_library(TBB::${_tbb_component} SHARED IMPORTED)
         set_target_properties(TBB::${_tbb_component} PROPERTIES
-                              INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_FILE}/@TBB_INC_REL_PATH@")
-
-        if (EXISTS "${_tbb_release_lib}")
-            set_target_properties(TBB::${_tbb_component} PROPERTIES
-                                  IMPORTED_LOCATION_RELEASE "${_tbb_release_lib}")
-            set_property(TARGET TBB::${_tbb_component} APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-        endif()
-
-        if (EXISTS "${_tbb_debug_lib}")
-            set_target_properties(TBB::${_tbb_component} PROPERTIES
-                                  IMPORTED_LOCATION_DEBUG "${_tbb_debug_lib}")
-            set_property(TARGET TBB::${_tbb_component} APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
-        endif()
+                              IMPORTED_CONFIGURATIONS "RELEASE;DEBUG"
+                              IMPORTED_LOCATION_RELEASE     "${_tbb_release_lib}"
+                              IMPORTED_LOCATION_DEBUG       "${_tbb_debug_lib}"
+                              INTERFACE_INCLUDE_DIRECTORIES "${_tbb_root}/include"@TBB_IMPLIB@@TBB_COMPILE_DEFINITIONS@)
 
         # Add internal dependencies for imported targets: TBB::tbbmalloc_proxy -> TBB::tbbmalloc
         if (_tbb_component STREQUAL tbbmalloc_proxy)
@@ -67,10 +74,16 @@ foreach (_tbb_component ${TBB_FIND_COMPONENTS})
         list(APPEND TBB_IMPORTED_TARGETS TBB::${_tbb_component})
         set(TBB_${_tbb_component}_FOUND 1)
     elseif (TBB_FIND_REQUIRED AND TBB_FIND_REQUIRED_${_tbb_component})
-        message(STATUS "Missed required Intel TBB component: ${_tbb_component}")
-        set(TBB_FOUND FALSE)
-        set(TBB_${_tbb_component}_FOUND 0)
+        message(FATAL_ERROR "Missed required Intel TBB component: ${_tbb_component}")
     endif()
 endforeach()
+
+unset(_tbb_x32_subdir)
+unset(_tbb_x64_subdir)
+unset(_tbb_arch_subdir)
+unset(_tbb_compiler_subdir)
+unset(_tbbmalloc_proxy_ix)
+unset(_tbbmalloc_ix)
+unset(_tbb_lib_path)
 unset(_tbb_release_lib)
 unset(_tbb_debug_lib)


### PR DESCRIPTION
It adds TBBInstallConfig module which can generate TBBConfig.cmake and TBBConfigVersion.cmake for different TBB installations. It is a new functionality which doesn't affect legacy interfaces.

It partly addresses the issues raised in PR #119 according to [this](https://github.com/01org/tbb/pull/119#issuecomment-460488355) comment.

Please find detailed documentation [in the TBBInstallConfig section of cmake/README.rst](https://github.com/AlexVeprev/tbb/tree/cmake-install-config/cmake#tbbinstallconfig).

Examples of the generated files can be found in a temporary folder [cmake/demo](https://github.com/AlexVeprev/tbb/tree/cmake-install-config/cmake/demo):

How these files were created:
```
cd /tmp/tbb/cmake
mkdir demo
cmake -DINSTALL_DIR=./demo -DSYSTEM_NAME=Linux -DTBB_VERSION_FILE=../include/tbb/tbb_stddef.h -P tbb_config_installer.cmake
```

@hjmjohnson, I would really appreciate if you can take a look and provide some feedback.