### PR TITLE
[Archive] Publishing prototypes for concurrent hash table interface research from 2011

### DIFF
--- a/src/proto/Makefile
+++ b/src/proto/Makefile
@@ -1,0 +1,74 @@
+# Copyright (C) 2005-2011, Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+#
+
+default:
+	@-echo Usage: gmake [test_{name}][debug_{name}][clean]
+
+tbb_root=../..
+tbb_strict=0
+BUILDING_PHASE=0
+include $(tbb_root)/build/common.inc
+
+VPATH = $(tbb_root)/src/tbb/$(ASSEMBLY_SOURCE) $(tbb_root)/src/tbb $(tbb_root)/src/test $(work_dir)_$(cfg)
+include $(tbb_root)/build/common_rules.inc
+CPLUS_FLAGS += $(INCLUDE_KEY) $(tbb_root)/src $(INCLUDE_KEY) $(tbb_root)/include/tbb $(INCLUDE_KEY) $(tbb_root)/src/test $(INCLUDE_KEY) $(tbb_root)/src/tbb
+DEBUG_SUFFIX=$(findstring _debug,_$(cfg))
+
+ifeq ($(tbb_os),windows)
+    export PATH := $(work_dir)_$(cfg);$(PATH)
+else
+    ifeq ($(tbb_os),macos)
+        export DYLD_LIBRARY_PATH := $(work_dir)_$(cfg):$(DYLD_LIBRARY_PATH)
+    else
+        export LD_LIBRARY_PATH := $(work_dir)_$(cfg):$(LD_LIBRARY_PATH)
+    endif
+endif
+
+#tbb_root = $(subst source$(SLASH)test,,$(CWD))tbb/1.0
+#TARGETS = $(subst .cpp,.exe,$(wildcard test_*.cpp time_*.cpp))
+#.PHONY: clean tbb tbb_release tbb_debug
+
+$(TBB.LIB): tbb_$(cfg)
+tbb: tbb_release tbb_debug
+tbb_%::
+	$(MAKE) -C $(tbb_root)/src $@
+
+# Rule for generating executable test
+%.exe: %.$(OBJ) $(TBB.LIB)
+	$(CPLUS) $(OUTPUT_KEY)$@ $(CPLUS_FLAGS) $^ $(LIBS) $(LINK_FLAGS)
+
+time_%: time_%.exe
+	./$^ $(args)
+
+test_%: test_%.exe
+	./$^ $(args)
+
+debug_%: test_%.exe
+	$(debugger) ./$^ $(debug_args)
+
+dtime_%: time_%.exe
+	$(debugger) ./$^ $(debug_args)
+
+clean:
+	$(RM) *.$(OBJ) *.exe *.$(DLL) *.$(LIBEXT) *.res *.map *.ilk *.pdb *.exp *.*manifest *.tmp *.d
+	
+#$(TARGETS)::
+#	-$(MAKE) -C $(@D)  -f $(EXAMPLE_MAKEFILE) $(subst .,,$(suffix $@)) CXX="$(CPLUS)"
+
+# Include automatically generated dependences
+-include *.d

--- a/src/proto/accessing.h
+++ b/src/proto/accessing.h
@@ -1,0 +1,133 @@
+/*
+    Copyright (C) 2005-2011, Intel Corporation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+
+
+*/
+
+#ifndef __TBB_accessing_H
+#define __TBB_accessing_H
+
+namespace tbb {
+
+//! @cond INTERNAL
+namespace internal {
+    class empty_deleter {
+        void operator()(void*) {}
+    };
+} // namespace internal
+//! @endcond
+
+template<typename T, typename Synchronizer, typename Deleter=internal::empty_deleter >
+class accessing : public Synchronizer {
+    T my_value;
+public:
+    //! Rebind for different types
+    template<typename U, typename S = Synchronizer, typename M = Deleter>
+    struct rebind {
+        typedef accessing<U, S, M> other;
+    };
+    
+    typedef Synchronizer synchronizer_type;
+    //typedef synchronizer_type::access access;
+    typedef Deleter deleter_type;
+    // Standard types
+    typedef T value_type;
+    typedef value_type *pointer;
+    typedef const value_type *const_pointer;
+    typedef value_type &reference;
+    typedef const value_type &const_reference;
+
+    //! Default constructor
+    accessing() {}
+    //! Construct by value without access
+    accessing( const_reference v ) : my_value( v ) {}
+    //! Construct by value with accessor acquired
+    template<typename Accessor>
+    accessing( const_reference v, Accessor &a )
+        : my_value( v ), Synchronizer(a) { }
+    //! Return reference to underlying type.
+    reference unprotected_ref() const { return const_cast<reference>(my_value); }
+
+    //! Combines data access and locking
+    template<typename Access>
+    class accessor : protected access_holder<Access> {
+        void operator=( const accessor & ) const; // Deny access
+    public:
+        // Standard types
+        typedef T value_type;
+        typedef value_type *pointer;
+        typedef const value_type *const_pointer;
+        typedef value_type &reference;
+        typedef const value_type &const_reference;
+        typedef Deleter deleter_type;
+
+        //! Create empty accessor
+        accessor( const deleter_type &d = deleter_type() ) : my_node(NULL), deleter(d) {}
+        //! Move and downgrade
+        accessor( const accessor & );
+        //! Move
+        accessor( const const_accessor & );
+        //! Destroy result after releasing the underlying reference.
+        ~accessor() {
+            // do not call deleter(my_node); here due to semantics of simple??? synchronizer
+            my_node = NULL; // my_lock.release() is called in scoped_lock destructor
+        }
+        //! Attempt to acquire an access right. Returns true if successful; false otherwise
+        bool try_acquire( simple_synchronizer &item ) {
+            if( !scoped_t::try_acquire( item, false ) )
+                return false;
+            my_node = &item;
+            return true;
+        }
+        //! True if result is empty.
+        bool empty() const { return !my_node; }
+        //! True if holder is empty.
+        bool owns_lock() const;
+        //! Synonym of empty()
+        explicit operator bool() const { return !my_node; }
+        //! Release access, return synchronizer
+        simple_synchronizer *release() {
+            if( simple_synchronizer *n = my_node ) {
+                scoped_t::release();
+                my_node = 0;
+                return n;
+            }
+            return 0;
+        }
+        //! Return reference to associated value in hash table.
+        reference operator*() const { return const_accessor::internal_get_value(); }
+        //! Return pointer to associated value in hash table.
+        pointer operator->() const { return &const_accessor::internal_get_value(); }
+        //! Return pointer to associated value in hash table.
+        pointer get() const { return &const_accessor::internal_get_value(); }
+        //! Return reference to deleter
+        deleter_type &get_deleter() { return deleter; }
+        
+    private:
+        friend simple_synchronizer;
+        reference internal_get_value() const {
+            __TBB_ASSERT( my_node, "attempt to dereference empty accessor" );
+            return my_node->my_value;
+        }
+        simple_synchronizer *my_node;
+        deleter_type deleter;
+    };
+};
+
+}//namespace tbb
+
+#endif//__TBB_accessing_H

--- a/src/proto/guarded.h
+++ b/src/proto/guarded.h
@@ -1,0 +1,195 @@
+/*
+    Copyright (C) 2005-2011, Intel Corporation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+
+
+*/
+
+#ifndef __TBB_guarded_H
+#define __TBB_guarded_H
+
+#include "tbb/spin_mutex.h"
+
+namespace tbb {
+
+template <typename T, class M = tbb::spin_mutex>
+class guarded;
+
+//! @cond INTERNAL
+namespace internal {
+    //! The class is used to access data from guarded<T> class.
+    template <typename T, class M>
+    class guarded_accessor_provider {
+        void operator=( const guarded_accessor_provider& ) const; // Deny access
+        guarded_accessor_provider( const guarded_accessor_provider& ); // Deny access
+    public:
+        //! True if the accessor is empty.
+        bool empty() const {
+            return !my_guarded;
+        }
+
+        //! Create empty result
+        guarded_accessor_provider() {}
+
+        //! Destroy result after releasing the underlying reference.
+        ~guarded_accessor_provider() {
+            my_guarded = NULL; // my_lock.release() is called in scoped_lock destructor
+        }
+
+        //! Constructor for guarded<T>
+        guarded_accessor_provider(guarded<T, M>& guarded_item) {
+            my_guarded = &guarded_item;
+            my_lock.acquire (guarded_item.my_mutex);
+        }
+
+        //! Return reference to guarded value
+        T& operator*() const {
+            __TBB_ASSERT( my_guarded, "attempt to dereference empty accessor" );
+            return my_guarded->my_value;
+        }
+
+        //! Return pointer to guarded value
+        T* operator->() const {
+            return &operator*();
+        }
+
+        //! Explicit locking
+        void acquire() {
+            my_lock.acquire(my_guarded->my_mutex);
+        }
+
+        bool try_acquire() {
+            return my_lock.try_acquire(my_guarded->my_mutex);
+        }
+
+        //! Explicit releasing
+        void release() {
+            my_lock.release();
+        }
+
+        //! Changes the guarded<T> value the accessor holds
+        void acquire(guarded<T, M>& item) {
+            my_lock.acquire(item.my_mutex);
+            my_guarded = &item;
+        }
+
+    protected:
+        guarded<T, M>* my_guarded;
+        typename M::scoped_lock my_lock;
+    };
+
+    //! Const accessor class. It is used to access read-only data
+    template <typename T, class M, bool is_rw_mutex> 
+    class guarded_const_accessor_provider : public guarded_accessor_provider<T, M> {
+    public:
+        //! Constructor for guarded<T>
+        guarded_const_accessor_provider(guarded<T, M>& guarded_item) {
+            this->my_guarded = &guarded_item;
+            this->my_lock.acquire (guarded_item.my_mutex);
+        }
+
+        //! Return reference to guarded value
+        const T& operator*() const {
+            __TBB_ASSERT( this->my_guarded, "attempt to dereference empty accessor" );
+            return this->my_guarded->my_value;
+        }
+
+        //! Return pointer to guarded value
+        const T* operator->() const {
+            return &operator*();
+        }
+    };
+
+    //! Explicit specialization of const_accessor for readerwriter mutex
+    template<typename T, class M>
+    class guarded_const_accessor_provider<T, M, true> : public guarded_accessor_provider<T, M>{
+    public:
+        //! Constructor for guarded<T>
+        guarded_const_accessor_provider(guarded<T, M>& guarded_item) {
+            this->my_guarded = &guarded_item;
+            this->my_lock.acquire (guarded_item.my_mutex, false);
+        }
+
+        //! Explicit locking
+        void acquire() {
+            this->my_lock.acquire(this->my_guarded->my_mutex, false);
+        }
+
+        bool try_acquire() {
+            return this->my_lock.try_acquire(this->my_guarded->my_mutex, false);
+        }
+
+        //! Changes the guarded<T> value the accessor holds
+        void acquire(guarded<T, M>& item) {
+            this->my_lock.acquire(item.my_mutex, false);
+            this->my_guarded = &item;
+        }
+
+        //! Return reference to guarded value
+        const T& operator*() const {
+            __TBB_ASSERT( this->my_guarded, "attempt to dereference empty accessor" );
+            return this->my_guarded->my_value;
+        }
+
+        //! Return pointer to guarded value
+        const T* operator->() const {
+            return &operator*();
+        }
+    };
+}// end of namespace internal
+
+//! The class provides locked access to data
+template <typename T, class M> 
+class guarded {
+public:
+    //! Constructor
+    guarded (T value): my_value(value), my_mutex(){};
+    //! Copy constructor
+    guarded (const guarded& guarded_item): my_mutex(){ 
+        const_accessor ca_item(const_cast<guarded &> (guarded_item));
+        my_value = guarded_item.my_value;
+    }
+    //! Default constructor
+    guarded (): my_value(), my_mutex(){}; 
+    ~guarded(){};
+    // ! operator =
+    // It is required by TBB containers
+    guarded& operator =(const guarded& guarded_item) {
+        T tmp_value;
+        {
+            const_accessor ca_item (const_cast<guarded &> (guarded_item));
+            tmp_value = guarded_item.my_value;
+        }
+        {
+            accessor a_item (*this);
+            my_value = tmp_value;
+        }
+        return *this; 
+    } 
+
+    friend class internal::guarded_accessor_provider<T, M>;
+    friend class internal::guarded_const_accessor_provider<T, M, M::is_rw_mutex>;
+
+    typedef internal::guarded_accessor_provider<T, M> accessor; 
+    typedef internal::guarded_const_accessor_provider<T, M, M::is_rw_mutex> const_accessor; 
+private:
+    T my_value;
+    mutable M my_mutex;
+};
+
+}// namespace tbb
+
+#endif /* __TBB_guarded_H */

--- a/src/proto/synchronizer.h
+++ b/src/proto/synchronizer.h
@@ -1,0 +1,655 @@
+/*
+    Copyright (C) 2005-2011, Intel Corporation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+
+
+*/
+
+#if INTEL_PRIVATE
+/* !!! WARNING: !!!
+ * Interface of synchronizer has to be changed along with with interfaces of mutexes to comply C++0x concepts.
+ * So, current implementation of interface is strictly for usage as template argument of tbb containers.
+ */
+#endif
+#if INTEL_TRIAL==3
+#define __TBB_BTS 1
+#endif
+
+#ifndef __TBB_synchronizer_H
+#define __TBB_synchronizer_H
+
+#include "tbb_stddef.h"
+#include "atomic.h"
+#include <stdexcept>
+
+#ifndef __TBB_ASSERT_RACEPOINT
+#define __TBB_ASSERT_RACEPOINT(a)
+#endif
+#define __TBB_ASSERT_RACEPOINT_D(s) __TBB_ASSERT_RACEPOINT(("L%02xD%uO", (s.lock_bit<<4)+s.alive_bit, s.owners))
+
+namespace tbb {
+//! TBB-wide, all synchronization types
+// TODO: 'struct' enables "using tbb::access" and forces access:: before any tag (unless inherited)
+//   but 'namespace access' enables "using namespace tbb::access" which doesn't enforces access::
+//   but note, there is a global function access() defined by POSIX.1. So, compiler can ask to prefix with tbb::
+//   and the workaround is "using tbb::access" in non-global namespaces.
+struct access {
+    template<typename T>
+    struct const_ : T {
+        const_(const T &t) : T(t) {}
+    };
+    //! No access required
+    struct none {};
+    //! Serial access (not thread-safe)
+    struct serial {};
+    //! Pure owning with unsafe access
+    struct preserve {};
+    //! Concurrent access
+    struct concurrent {
+        bool is_shared;
+        //TODO: is_upgradable
+        concurrent(bool shared = false) : is_shared(shared) {}
+    };
+    //! Concurrent access with number of trials
+    struct concurrent_with_repeats : concurrent {
+        unsigned short ntrials; // to keep size of this structure = 4 bytes
+        concurrent_with_repeats(unsigned n, const concurrent &level)
+            : concurrent(level), ntrials(static_cast<unsigned short>(n)) {}
+    };
+    // TODO: concurrent_with_timeout and concurrent_try_upgradable tags
+    //! Serial const access (not thread-safe)
+    typedef const_<serial> const_serial;
+    //! Concurrent const access
+    typedef const_<concurrent> const_concurrent;
+    //! Concurrent const access with number of trials
+    typedef const_<concurrent_with_repeats> const_concurrent_with_repeats;
+    //! Exclusive concurrent access
+    static concurrent exclusive() { return concurrent(/*is_shared*/false); }
+    //! Exclusive concurrent const access
+    static const_concurrent const_exclusive() { return const_concurrent(exclusive()); }
+    //! Exclusive concurrent access with number of trials
+    static concurrent_with_repeats exclusive( unsigned n ) { return concurrent_with_repeats( n, exclusive() ); }
+    //! Exclusive concurrent const access with number of trials
+    static const_concurrent_with_repeats const_exclusive( unsigned n ) { return const_concurrent_with_repeats(exclusive(n)); }
+    //! Shared concurrent access
+    static concurrent shared() { return concurrent(/*is_shared*/true); }
+    //! Shared concurrent const access
+    static const_concurrent const_shared() { return const_concurrent(shared()); }
+    //! Shared concurrent access with number of trials
+    static concurrent_with_repeats shared( unsigned n ) { return concurrent_with_repeats( n, shared() ); }
+    //! Shared concurrent const access with number of trials
+    static const_concurrent_with_repeats const_shared( unsigned n ) { return const_concurrent_with_repeats(shared(n)); }
+    //! Results of acquisition/locking operation
+    enum result_t {//TODO: lock_result_t?
+        acquired, busy, timeout, doomed
+    };
+};
+
+template<typename T>
+struct access_tag_traits {
+    static const bool is_const = false;
+    typedef T mutable_type;
+    typedef access::const_<T> const_type;
+};
+template<>
+struct access_tag_traits<access::none> {
+    static const bool is_const = true;
+    typedef access::none mutable_type;
+    typedef access::none const_type;
+};
+template<>
+struct access_tag_traits<access::preserve> {
+    static const bool is_const = true;
+    typedef access::preserve mutable_type;
+    typedef access::preserve const_type;
+};
+template<typename C>
+struct access_tag_traits<access::const_<C> > {
+    static const bool is_const = true;
+    typedef C mutable_type;
+    typedef access::const_<C> const_type;
+};
+template<typename T>
+struct access_tag_traits<const T> {
+    static const bool is_const = true;
+    typedef T mutable_type;
+    typedef access::const_<T> const_type;
+};
+
+//! @cond INTERNAL
+namespace internal {
+    // moving templates with excplicit specializations out of classes
+
+#if __TBB_BTS
+    static inline int32_t __fetchbts4(volatile void *ptr, uintptr_t pos)
+    {
+        int32_t result=0;
+        __asm__ __volatile__("lock\nbts %3,%1\n"
+                             "adc $0, %0\n"
+                              : "=r"(result), "=m"(*(int32_t *)ptr)
+                              : "0"(result), "r"(pos), "m"(*(int32_t *)ptr)
+                              : "memory");
+        return result;
+    }
+#endif
+
+    // Traits-like class that specifies tags recognized by a synchronizer.
+    template<bool RW> struct access_specializator {
+        static access::concurrent default_access() { return access::exclusive(); }
+        static access::const_concurrent const_access() { return access::const_exclusive(); }
+    };
+    template<> struct access_specializator<true>  {
+        static access::concurrent default_access() { return access::exclusive(); }
+        static access::const_concurrent const_access() { return access::const_shared(); }
+    };
+
+    template<typename Mutex, bool RW = Mutex::is_rw_mutex>
+    struct mutex_handler_base : protected Mutex::scoped_lock {
+        mutex_handler_base(bool) {}
+        template<typename Synchronizer>
+        bool internal_try_lock(Synchronizer &sync) {
+            return Mutex::scoped_lock::try_acquire(sync);
+        }
+        bool internal_is_write() const { return false; }
+    };
+    template<typename Mutex>
+    struct mutex_handler_base<Mutex, true> : protected Mutex::scoped_lock {
+        bool is_write; // TODO: can be optimized out by Mutex refactoring
+        mutex_handler_base(bool w) : is_write( w ) {}
+        template<typename Synchronizer>
+        bool internal_try_lock(Synchronizer &sync) {
+            return Mutex::scoped_lock::try_acquire(sync, is_write);
+        }
+        bool internal_is_write() const { return is_write; }
+    };
+
+    // Simple memento state based on access type class
+    template<typename Access>
+    struct memento_state : Access {
+        typedef Access access_type;
+        memento_state( const Access &a ) : Access(a) {}
+        Access get_state() const { return *this; }
+    };
+    // Mementos for derivatives of access::concurrent must also be derived
+    template<> struct memento_state<access::concurrent_with_repeats> : memento_state<access::concurrent> {
+        typedef access::concurrent_with_repeats access_type;
+        uint16_t ntrials;
+        memento_state( const access_type &a ) : memento_state<access::concurrent>(a), ntrials(a.ntrials) {}
+        access_type get_state() const { return access::concurrent_with_repeats(ntrials, *this); }
+    };
+
+    //common synchronizer base
+    struct synchronizer_base {
+        typedef uint16_t uint16;
+        typedef uint32_t uint32;
+        typedef memento_state<access::none> none_state;
+        typedef memento_state<access::serial> serial_state;
+        typedef memento_state<access::preserve> preserve_state;
+        typedef memento_state<access::concurrent> concurrent_state;
+        typedef memento_state<access::concurrent_with_repeats> repeats_state;
+
+        template<typename State>
+        struct reset_memento : no_assign {
+            typedef typename State::access_type access_type;
+            State &state;
+            reset_memento( State &m ) : state(m) {}
+        };
+    };
+} // namespace internal
+//! @endcond
+
+class serial_synchronizer : public internal::synchronizer_base {
+public:
+    template<typename Access>
+    struct memento {
+        typedef internal::memento_state<typename access_tag_traits<Access>::mutable_type> state_type;
+    };
+    struct access_traits {
+        static access::serial default_access() { return access::serial(); }
+        static access::const_serial const_access() { return access::serial(); }
+    };
+    typedef void version_type; // access by value is not supported here
+
+    serial_synchronizer() {}
+    //! Acquire the lock without contention while constructing
+    template<typename Access>
+    serial_synchronizer( typename memento<Access>::state_type & ) { }
+    void init_lock( preserve_state & ) {}
+    access::result_t try_lock( preserve_state & ) { return access::timeout; }
+    access::result_t blocking_try_lock( preserve_state & ) { return access::timeout; }
+    // Doom *this.  Return true if there are no unreleased "acquires".
+    bool unlock( preserve_state & ) { return true; }
+    ~serial_synchronizer() {}
+};
+
+#if 0 // TODO: change interface to "methodless" memento state types.
+//! A synchronizer for any tbb mutex with "simple" deletion protocol.
+template<typename Mutex>
+class simple_synchronizer : protected Mutex {
+    typedef typename Mutex::scoped_lock scoped_t;
+
+    struct handler_base : protected internal::mutex_handler_base<Mutex> {
+        //! Create for required access
+        handler_base ( bool shared ) : internal::mutex_handler_base<Mutex>(!shared) {}
+#if INTEL_PRIVATE
+        // TODO: these are not supported yet by mutexes
+        //! Move and change access if necessary. empty() returns true if unsuccessful
+        handler_base ( handler_base &a, simple_synchronizer &sync );
+#endif//INTEL_PRIVATE
+        //! Acquire uncontended
+        void init_lock( simple_synchronizer &sync ) {
+            internal_try_lock( sync ); // TODO: mutex should provide better implementation
+        }
+        //! Attempt to acquire an access right. Can't block [for a long time]. Returns true if successful; false otherwise
+        bool try_lock( simple_synchronizer &sync ) {
+            if( !internal_try_lock( sync ) ) {
+                // we are unlucky, prepare for longer wait up to n trials
+                internal::AtomicBackoff trials;
+                do {
+                    if( !trials.bounded_pause() )
+                        return false;
+                } while( !internal_try_lock( sync ) );
+            }
+            return true;
+        }
+        //! Return true if all "acquires" have been released and *this is doomed already.
+        bool unlock( simple_synchronizer & ) {
+            scoped_t::release();
+            return false;
+        }
+    };
+
+public:
+    class concurrent_handler : public handler_base {
+    public:
+        //! Create for required access
+        concurrent_handler ( const access::concurrent a ) : handler_base(a.is_shared) {}
+        //! Try_acquire() returned false. May block. Complete transaction and decide to retry operation or return.
+        access::result_t try_finish_blocking_lock( simple_synchronizer & ) {
+            __TBB_Yield();
+            return access::busy;
+        }
+        access::concurrent get_status() const { // synchronizer is free to forget constness of access
+            return access::concurrent( handler_base::internal_is_write() );
+        }
+    };
+
+    class concurrent_with_repeats_handler : public handler_base {
+    public:
+        //! Create for required access
+        concurrent_with_repeats_handler ( const access::concurrent_with_repeats a ) : handler_base(a.is_shared), ntrials(a.ntrials) {}
+        //! Try_acquire() returned false. May block. Complete transaction and decide to retry operation or return.
+        access::result_t try_finish_blocking_lock( simple_synchronizer & ) {
+            __TBB_Yield();
+            if( !ntrials > 0) return access::timeout;
+            --ntrials;
+            return access::busy;
+        }
+        access::concurrent_with_repeats get_status() const { // synchronizer is free to forget constness
+            return access::concurrent_with_repeats( ntrials,
+                access::concurrent( handler_base::internal_is_write() ) );
+        }
+    protected:
+        uint16_t ntrials;
+    };
+
+    // memento mori.. memento access request/status
+    template<typename Access>
+    struct memento {
+        typedef typename internal::memento_handler<serial_synchronizer,
+            typename access_tag_traits<Access>::mutable_type>::type handler_type;
+    };
+
+    typedef Mutex mutex_type;
+    typedef internal::access_specializator<Mutex::is_rw_mutex> access;
+    typedef void version_type; // access by value is not supported here
+
+    simple_synchronizer() {}
+    //! Acquire the lock without contention while constructing
+    template<typename Access>
+    simple_synchronizer(typename memento<Access>::handler_type &ah) {
+        ah.init_lock( *this );
+    }
+    ~simple_synchronizer() {}
+
+    // Doom *this.  Return true if there are no unreleased "acquires".
+    bool doom() {
+        scoped_t lock( *this ); // acquire exclusively
+        return true;
+    }
+};
+
+// A versioned synchronizer for any tbb mutex with "simple" deletion protocol.
+template<typename Mutex>
+class simple_versioned_synchronizer : public simple_synchronizer {
+public:
+    typedef size_t version_type;
+    
+    void touch_version();
+    version_type get_version();
+    bool is_locked() const; // non-implementable with current mutexes
+
+protected:
+    volatile version_type my_version;
+};
+#endif//0
+
+
+//! A versioned mutual exclusive synchronizer with "deferred" deletion protocol.
+class versioned_synchronizer : public internal::synchronizer_base {
+public:
+    struct access_traits {
+        typedef access::concurrent default_access_type;
+        typedef access::const_concurrent const_access_type;
+        static access::concurrent default_access() { return access::exclusive(); }
+        static access::const_concurrent const_access() { return access::const_exclusive(); }
+        static const bool has_deferred_deletion_support = true;
+        static const bool has_multiple_owners_support = true;
+        static const bool has_exclusive_access_support = true;
+        static const bool has_shared_access_support = false;
+        static const bool has_versioned_lock_support = true;
+    };
+    typedef uint16 version_type;
+
+    // memento state
+    template<typename Access>
+    struct memento { // do not inherit from memento_state to map const and non-const access to the same state type.
+        typedef internal::memento_state<typename access_tag_traits<Access>::mutable_type> state_type;
+    };
+
+    // block of common empty methods which can't be inherited due to overloading
+    access::result_t try_lock( none_state & ) { return access::timeout; }
+    access::result_t try_lock( serial_state & ) { return access::acquired; }//TODO: probably, do atomic-less real locking?
+    bool unlock( none_state & ) { return false; }
+    bool unlock( serial_state & ) { return false; }
+    bool is_locked( none_state & ) { return false; }
+    bool is_locked( serial_state & ) { return false; } // TODO:ok???
+
+    //! Acquire a lock without contention
+    template<typename State>
+    void init_lock( State &memento ) {
+        state.init_lock( memento );
+    }
+    //! Concurrent initialization or resurrection after dooming with acquiring ownership. Returns true if success [and an item can be re-constructed]
+    template<typename State>
+    access::result_t try_lock( const reset_memento<State> &rmemento ) {
+        state_t s = state, old = s;
+        if( s.alive_bit ) return access::timeout; // as opposite to doomed
+        if( s.lock_bit ) return access::busy;
+        __TBB_ASSERT_RACEPOINT_D(s);
+        old.lifetime = 0; s.word = 0; s.alive_bit = 1;
+        s.init_lock( rmemento.state );
+        s.word = as_atomic(state.word).compare_and_swap( s.word, old.word );
+        return s.word == old.word ? access::acquired : access::busy;
+    }
+    //TODO: try_blocking_lock() for reset() ?
+    //! Try acquire ownership
+    access::result_t try_lock( preserve_state & ) {
+        state_t s = state; // no fence, just double-check optimization
+        if( !s.alive_bit ) return access::doomed;
+        if( s.owners > stop_owners ) return access::busy;
+        __TBB_ASSERT_RACEPOINT_D(s);
+        s.word = as_atomic(state.word)++;
+        if( !s.alive_bit || s.owners > stop_owners ) { // we must decrease it back
+            __TBB_ASSERT_RACEPOINT_D(s);
+            s.word = --as_atomic(state.word);
+            if( s.alive_bit && !s.owners && !s.lock_bit ) {
+                // but we don't want to be a doomer, increase again instead of dooming.
+                state_t old = s; s.lifetime = 1;
+                __TBB_ASSERT_RACEPOINT_D(old);
+                s.word = as_atomic(state.word).compare_and_swap( s.word, old.word );
+                return s.word == old.word? access::acquired : s.alive_bit ? access::busy : access::doomed;
+            }
+            __TBB_ASSERT(s.owners < fatal_owners, "Broken synchronizer instance");
+            if( s.owners >= fatal_owners )
+                throw std::overflow_error("Excess attach operation");
+            return s.alive_bit? access::busy : access::doomed;
+        }
+        return access::acquired;
+    }
+    //! Unlock ownership, return true if the last owner
+    bool unlock( preserve_state & ) {
+        state_t s = state; // no fence, just optimization
+        __TBB_ASSERT(s.alive_bit, "Doomed before unlocked");
+        __TBB_ASSERT_RACEPOINT_D(s);
+        if(s.owners == 1 && !s.lock_bit) { // it's the last one, use one atomic op to unset alive_bit also
+            state_t old = s; s.lock_bit = 1; s.lifetime = 0; //alive_bit = 0 owners = 0
+            s.word = as_atomic(state.word).compare_and_swap( s.word, old.word );
+            if( s.word == old.word ) return true; // success, alive_bit is unset by me
+            __TBB_ASSERT_RACEPOINT_D(s);
+            __TBB_ASSERT(s.alive_bit, "Doomed before unlocked");
+        }
+        s.word = --as_atomic(state.word);
+        __TBB_ASSERT(s.alive_bit, "Doomed before unlocked");// before decrement, nobody would unset alive_bit
+        if( !s.owners && !s.lock_bit ) {
+            state_t old = s; s.lock_bit = 1; s.lifetime = 0; // alive_bit always set together with lock_bit
+            __TBB_ASSERT_RACEPOINT_D(old);
+            s.word = as_atomic(state.word).compare_and_swap( s.word, old.word );
+            if( s.word == old.word ) return true; // success, alive_bit is unset by me
+        }
+        else if( s.owners >= fatal_owners ) {
+            __TBB_ASSERT(s.owners < fatal_owners, "Broken synchronizer instance");
+            as_atomic(state.word)++; // try to fix
+            throw std::underflow_error("Excess detach operation");
+        }
+        return false;
+    }
+    //! Try acquire exclusive access
+    access::result_t try_lock( concurrent_state & ) {
+        state_t s; s.word = as_atomic(state.word);// TODO: do we need fence here?
+        if( !s.alive_bit ) return access::doomed;
+        if( s.lock_bit ) return access::busy;
+        // Note, alive_bit always set together with lock_bit
+        // but at this point, other threads can doom, destroy, and recycle the object
+        __TBB_ASSERT_RACEPOINT_D(s);
+#if __TBB_BTS
+        if( !internal::__fetchbts4(&state, 16) )
+#else
+        state_t old = s; s.lock_bit = 1; // using half-word op to avoid contention with owners
+        // TODO: add support for architestures without half-word atomics
+        // TODO: use bit_test_set() instead
+        s.lock_version = as_atomic(state.lock_version).compare_and_swap( s.lock_version, old.lock_version );
+        if( s.lock_version == old.lock_version )
+#endif
+        { // success
+            __TBB_ASSERT_RACEPOINT(());
+            s = state; // but is it doomed? //TODO: do we need fence here?
+            if( s.alive_bit ) return access::acquired;
+            else { // revert to unlocked
+                s.lock_bit = 0;
+                as_atomic(state.lock_version) = s.lock_version;
+                return access::doomed;
+            }
+        } else
+            return access::busy;
+    }
+    //! Unlock access, return true if the last owner
+    bool unlock( concurrent_state & ) {
+        state_t s; s.lock_version = state.lock_version; // no fence needed
+        __TBB_ASSERT(s.lock_bit, "Excess unlock operation");
+        if( !s.lock_bit ) {
+            throw std::underflow_error("Excess unlock operation");
+        }
+        __TBB_ASSERT_RACEPOINT(());
+        as_atomic(state.lock_version) = s.lock_version + 1; // store with release
+        // after this point anything could happen: another lock is acquired, last owner detached...
+        __TBB_ASSERT_RACEPOINT(());
+        s.word = as_atomic(state.word); // load with acquire TODO: use one full memory barrier instead?
+        if( s.alive_bit && !s.owners && !s.lock_bit ) {
+            state_t old = s; s.lock_bit = 1; s.lifetime = 0; // alive_bit always set together with lock_bit
+            __TBB_ASSERT_RACEPOINT_D(old);
+            s.word = as_atomic(state.word).compare_and_swap( s.word, old.word );
+            if( s.word == old.word ) return true; // success, alive_bit is unset by me
+        }
+        return false;
+    }
+    //! Transform ownership into acquired lock
+    bool move_to( concurrent_state &/*dest*/, preserve_state &/*from_expiring*/ ) {
+        state_t old, s = state; // no fence, just optimization
+        __TBB_ASSERT(s.owners, NULL); __TBB_ASSERT(s.alive_bit, NULL);
+        if( !s.lock_bit ) { // try make it by one shot
+            old = s; s.lock_bit = 1; s.lifetime--;
+            __TBB_ASSERT_RACEPOINT_D(old);
+            s.word = as_atomic(state.word).compare_and_swap( s.word, old.word );
+            __TBB_ASSERT(s.alive_bit, NULL);
+            if( s.word == old.word ) return true; // success, moved
+            __TBB_ASSERT(s.owners, NULL);
+        }
+        //reduce contention by working with lock_bit only
+        do { // TODO: !!! use bit_test_and_set instead !!!
+            for( internal::AtomicBackoff trials; s.lock_bit; s.lock_version = as_atomic(state.lock_version) ) {
+                trials.pause(); // wait until unlocked
+                __TBB_ASSERT_RACEPOINT(());
+            }
+            __TBB_ASSERT_RACEPOINT(());
+            old.lock_version = s.lock_version; s.lock_bit = 1;
+            s.lock_version = as_atomic(state.lock_version).compare_and_swap( s.lock_version, old.lock_version );
+        } while( s.lock_version != old.lock_version );
+        __TBB_ASSERT_RACEPOINT(());
+        as_atomic(state.lifetime)--; // don't bother with !owners, we have lock
+        __TBB_ASSERT(state.alive_bit, NULL);
+        return true;
+    }
+    //! Transform acquired lock into ownership
+    bool move_to( preserve_state &/*dest*/, concurrent_state &/*from_expiring*/ ) {
+        state_t s;
+        for(;;) {
+            s.word = as_atomic(state.word)++;
+            __TBB_ASSERT(s.lock_bit, NULL); __TBB_ASSERT(s.alive_bit, NULL);
+            if( s.owners > stop_owners ) { // no enough room, we must decrease it back
+                __TBB_ASSERT_RACEPOINT_D(s);
+                s.word = --as_atomic(state.word);
+                __TBB_ASSERT(s.owners < fatal_owners, "Broken synchronizer instance");
+                if( s.owners >= fatal_owners )
+                    throw std::overflow_error("Excess attach operation");
+                __TBB_Yield(); // continue;
+                __TBB_ASSERT_RACEPOINT_D(s);
+            } else break;
+        }
+        __TBB_ASSERT_RACEPOINT_D(s);
+        as_atomic(state.lock_version) = s.lock_version + 1; // store with release
+        __TBB_ASSERT(state.alive_bit, NULL);
+        return true;
+    }
+    //! Transfer state of the same type
+    template<typename State>
+    bool move_to( State &dest, State &from_expiring ) {
+        dest = from_expiring;// TODO: check, is it necessary?
+        return true;
+    }
+    //! Try acquire exclusive access within N trials
+    access::result_t try_lock( repeats_state &rep ) {
+        access::result_t r = try_lock( static_cast<concurrent_state&>(rep) );
+        if( rep.ntrials ) --rep.ntrials;
+        else if( r == access::busy )
+            return access::timeout;
+        return r;
+    }
+    //! Try acquire until acquired, timeout or doomed
+    template<typename State>
+    access::result_t blocking_try_lock( State &memento ) {
+        access::result_t r = try_lock( memento );
+        if( r == access::busy ) {
+            //internal::AtomicBackoff backoff;
+            do {
+                //backoff.pause();
+                __TBB_Yield();
+                __TBB_ASSERT_RACEPOINT(());
+                r = try_lock( memento );
+            } while( r == access::busy );
+        }
+        return r;
+    }
+    //! Recycle the synchronizer with doomed state (after execution of destructor of an item). Call then try_lock(reset) for re-initialization
+    void recycle() {
+        __TBB_ASSERT( state.lock_bit && !state.alive_bit, "recycle() can be used only after unlock() returns access::doomed");
+        state.lock_version = 0;
+    }
+    //! Return special memento type for the first time locking by try_lock
+    template<typename State>
+    reset_memento<State> reset( State &m ) {
+        return reset_memento<State>( m );
+    }
+    //! Return memento instance for given access (for "auto" of C++0x)
+    template<typename Access>
+    typename memento<Access>::state_type get_memento( const Access &a ) {
+        return typename memento<Access>::state_type( a );
+    }
+    //! Returns lock version
+    version_type get_version() const {
+        return const_cast<volatile uint16 &>(state.lock_version); // compiler fence but no HW fence
+    }
+    //! Returns true if attached by any owner(s)
+    bool is_locked( const access::preserve & ) const {
+        state_t s; s.lifetime = const_cast<volatile uint16 &>(state.lifetime); // compiler fence but no HW fence
+        return s.owners > 0;
+    }
+    //! Returns true if locked for access
+    bool is_locked( const access::concurrent & ) const {
+        state_t s; s.lock_version = const_cast<volatile uint16 &>(state.lock_version); // compiler fence but no HW fence
+        return s.lock_bit;
+    }
+    //! Returns true if locked by any sync level except access::preserved
+    bool is_locked() const {
+        state_t s; s.word = const_cast<volatile uint32 &>(state.word); // compiler fence but no HW fence
+        return s.lock_bit;// TODO?: && s.owners;
+    }
+    //! Returns true if doomed
+    bool is_doomed() const {
+        state_t s; s.lifetime = const_cast<volatile uint16 &>(state.lifetime); // compiler fence but no HW fence
+        return !s.alive_bit;
+    }
+
+    explicit versioned_synchronizer(bool alive = true) {
+        __TBB_ASSERT( 1024 + stop_owners < fatal_owners && fatal_owners < max_owners, NULL);
+        __TBB_ASSERT( &state.lock_version > &state.lifetime, NULL);
+        state.word = 0; state.alive_bit = alive;
+    }
+    //! Acquire the lock without contention while constructing
+    template<typename Memento>
+    versioned_synchronizer( Memento &m ) { state.word = 0; state.alive_bit = 1; state.init_lock( m ); }
+    ~versioned_synchronizer() {}
+
+protected:
+    template<typename T>
+    static inline atomic<T>& as_atomic( T& t ) {
+        return *(atomic<T>*)&t;
+    }
+    union state_t {
+        uint32 word;
+        struct {
+            uint16 lifetime;
+            uint16 lock_version;
+        };
+        struct {
+            uint16 owners : 15;
+            uint16 alive_bit : 1;
+            uint16 lock_bit : 1;
+            uint16 : 15;
+        };
+        void init_lock( none_state & ) {}
+        void init_lock( serial_state & ) {}
+        void init_lock( preserve_state & ) { owners = 1; }
+        void init_lock( concurrent_state & ) { lock_bit = 1; }
+    } mutable state;
+    static const uint16 max_owners = (1 << 15)-1;
+    static const uint16 fatal_owners = max_owners - 127;
+    static const uint16 stop_owners = 3 << 13; // safety margin = (fatal_owners - stop_owners) = ~8000 threads
+};
+
+}//namespace tbb
+
+#endif//__TBB_synchronizer_H

--- a/src/proto/test_accessing.cpp
+++ b/src/proto/test_accessing.cpp
@@ -1,0 +1,379 @@
+/*
+    Copyright (C) 2005-2011, Intel Corporation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+
+
+*/
+
+#define TBB_USE_ASSERT 1
+
+struct debug_point {
+    const char *file, *func;
+    int line;//TODO: add global point number
+    debug_point(const char *f, const char *m, int l) : file(f), func(m), line(l) {}
+    void test_race(const char *f = 0);
+    template<typename T> void test_race(const char *f, T arg );
+    template<typename T, typename U> void test_race(const char *f, T arg0, U arg1);
+};
+#define __TBB_ASSERT_RACEPOINT(args) {static ::debug_point point(__FILE__, __FUNCTION__, __LINE__); point.test_race args;}
+//TODO:CHECKPOINT
+//TODO:use __PRETTY_FUNCTION__ for GCC and __FUNCDNAME__ or __FUNCSIG__ for VC
+#include "proto/synchronizer.h"
+
+#include "tbb/task_scheduler_init.h"
+#include "tbb/aligned_space.h"
+#include "tbb/enumerable_thread_specific.h"
+#include "harness.h"
+#include "perf/harness_barrier.h"
+#include <cstdlib>
+#include <cstdio>
+#include <ctime>
+#include <vector>
+using namespace tbb;
+using namespace std;
+
+static atomic<size_t> trace_counter;
+static const size_t trace_buffer_size = 1<<16;
+struct trace_record {
+    int thread;
+    const debug_point *point;
+    const char* type;
+    const char* msgf;
+    long word[4];
+} trace_buffer[trace_buffer_size];
+
+#define __TBB_TRACE(tid, msg) {static ::debug_point point(__FILE__, __FUNCTION__, __LINE__); trace_event(tid, point, "trace", msg, 0, 0);}
+
+template<typename T, typename U>
+inline void trace_event( int thread, const debug_point &dp, const char* t, const char* f = 0, T arg0 = 0, U arg1 = 0 ) {
+    trace_record &r = trace_buffer[trace_counter++ % trace_buffer_size];
+    r.thread = thread;
+    r.point = &dp;
+    r.type = t;
+    r.msgf = f;
+    r.word[0] = arg0;
+    r.word[1] = arg1;
+}
+void trace_dump(FILE *f, size_t from = 0, size_t stop = 0) {
+    if(!stop) stop = (from-1)%trace_buffer_size;
+    for(size_t i = from; i != stop; i = (i+1)%trace_buffer_size) {
+        if(i == trace_counter) fputs("->\n", f);
+        trace_record &r = trace_buffer[i];
+        if(!r.point) continue;
+        for(int n = r.thread; n > 0; n--) fprintf(f, "\t\t");
+        fprintf(f, "#%d %s:%d ", r.thread, r.point->func, r.point->line);
+        if(r.msgf) fprintf(f, r.msgf, r.word[0], r.word[1]);
+        if(r.type) fprintf(f, " %s", r.type);
+        fputs("\n", f);
+    }
+}
+
+struct race_context {
+    int thread, point;
+    unsigned long path;
+};
+static enumerable_thread_specific<race_context> tls;
+// random race scheduler
+struct race_scheduler {
+    static bool is_active;
+    static Harness::SpinBarrier barrier;
+
+    race_scheduler() {
+    #if __APPLE__
+        srandomdev();
+    #elif __linux__
+        if(Verbose) puts("Warning: using poor random number generator");
+        //todo: read /dev/random
+        srandom(clock());
+    #else
+    #   define random() rand()
+        srand(clock());
+        if(Verbose) puts("Warning: using poor random number generator");
+    #endif
+    }
+    template<typename Test>
+    static void execute(int nthreads, const Test &test) {
+        race_context &rc = tls.local(); // reset main thread
+        rc.thread = -1; rc.path = 0; rc.point = 0;
+        barrier.initialize( nthreads );
+        is_active = true;
+        NativeParallelFor(nthreads, test);
+        is_active = false;
+    }
+    static bool next_iteration(int i, int t) {
+        ASSERT(is_active, 0);
+        if(i >= 10000) return false;
+        race_context &rc = tls.local();
+        rc.thread = t;
+        rc.point = 0;
+        rc.path = random();
+        if(Verbose && !t && i % 1000 == 0) {
+            printf("iteration %d\n", i);
+        }
+        __TBB_TRACE(t, "finished");
+        barrier.wait();
+        if(!t) trace_counter = 0;
+        barrier.wait();
+        return true;
+    }
+    static void open_race_hole() {
+    #if __APPLE__ || __linux__
+        usleep(1);
+    #else
+        __TBB_Yield();
+    #endif
+    }
+    static void test_race(const debug_point &dp, const char *f = NULL, long arg0 = 0, long arg1 = 0) {
+        if(!is_active) return;
+        race_context &rc = tls.local();
+        int p = rc.point++%(sizeof(long)*8);
+        bool halt = rc.path&(1<<p);
+        if( halt )
+            open_race_hole();
+        trace_event(rc.thread, dp, halt?"- sleeped":0, f, arg0, arg1);
+    }
+    static void print_context() {
+        if(!is_active) { puts("Serial context"); return; }
+        __TBB_TRACE(tls.local().thread, "aborted");
+        puts("Race context:");
+        trace_dump(stdout, 0, trace_counter);
+    }
+} init_rs;
+bool race_scheduler::is_active = false;
+Harness::SpinBarrier race_scheduler::barrier(0);
+
+void debug_point::test_race(const char *f) {
+    race_scheduler::test_race(*this, f, 0, 0 );
+}
+template<typename T>
+void debug_point::test_race(const char *f, T arg) {
+    race_scheduler::test_race(*this, f, long(arg), 0 );
+}
+template<typename T, typename U>
+void debug_point::test_race(const char *f, T arg0, U arg1) {
+    race_scheduler::test_race(*this, f, long(arg0), long(arg1) );
+}
+
+/////////////////////////////////////////////////////////////////////
+
+template<typename T>
+bool is_const(T = T()) {
+    return access_tag_traits<T>::is_const;
+}
+
+void test_access_tags() {
+    // Using access levels here - due to <cstdio> included
+    using tbb::access;
+    ASSERT( is_const( access::const_shared() ), 0);
+    ASSERT(!is_const( access::shared() ), 0);
+    ASSERT( is_const<const access::serial>(), 0);
+    ASSERT(!is_const<access::serial>(), 0);
+    //...
+}
+
+template<typename Synchronizer>
+struct test_synchronizer {
+    // types assert
+    typedef typename Synchronizer::version_type *ver_ptr;
+    typedef typename Synchronizer::template memento<tbb::access::none>::state_type memento_none;
+    typedef typename Synchronizer::template memento<tbb::access::serial>::state_type memento_serial;
+    typedef typename Synchronizer::template memento<tbb::access::preserve>::state_type memento_preserve;
+    typedef typename Synchronizer::template memento<tbb::access::concurrent>::state_type memento_concurrent;
+    typedef typename Synchronizer::template memento<typename Synchronizer::access_traits::default_access_type>::state_type memento_default;
+    typedef typename Synchronizer::template memento<typename Synchronizer::access_traits::const_access_type>::state_type memento_const;
+    // declarations above are really MONSTROUS... :(
+
+    void serial_compliance() {
+        // Using access levels here - due to <cstdio> included
+        using tbb::access;
+        ASSERT(!is_const( Synchronizer::access_traits::default_access() ), 0);
+        ASSERT( is_const( Synchronizer::access_traits::const_access() ), 0);
+        memento_none mn = access::none();
+        memento_serial ms = access::serial();
+        memento_preserve mp = access::preserve();
+        memento_concurrent me = access::exclusive();
+        memento_concurrent mh = access::shared();
+        memento_default md = Synchronizer::access_traits::default_access();
+        memento_const mc = Synchronizer::access_traits::const_access();
+
+        Synchronizer litex( mp ); // lifetime exclusive..?
+        litex.init_lock( me ); // common initialization sequence
+
+        // fake locking
+        litex.init_lock( mn );
+        ASSERT( litex.try_lock( mn ) == access::timeout, 0 );
+        ASSERT( litex.blocking_try_lock( mn ) == access::timeout, 0 );
+        ASSERT(!litex.unlock( mn ), 0 );
+        litex.init_lock( ms );
+        ASSERT( litex.try_lock( ms ) == access::acquired, 0 );
+        ASSERT( litex.blocking_try_lock( ms ) == access::acquired, 0 );
+        ASSERT(!litex.unlock( ms ), 0 );
+
+        // real locking
+        memento_preserve mp1 = access::preserve();
+        if( Synchronizer::access_traits::has_multiple_owners_support ) {
+            ASSERT( litex.try_lock( mp1 ) == access::acquired, 0 );
+            ASSERT(!litex.unlock( mp1 ), 0);
+        } else ASSERT( litex.try_lock( mp1 ) == access::timeout, 0 );
+
+        if(!Synchronizer::access_traits::has_exclusive_access_support &&
+            !Synchronizer::access_traits::has_shared_access_support ) {
+            // check dooming by last owner
+            ASSERT( litex.unlock( mp ), 0);
+            return; // nothing to test any more
+        }
+
+        memento_concurrent me1 = access::exclusive();
+        if(!Synchronizer::access_traits::has_exclusive_access_support ) {
+            ASSERT( litex.try_lock( me1 ) == access::acquired, 0 );
+            ASSERT(!litex.unlock( me1 ), 0);
+        } else ASSERT( litex.try_lock( me1 ) == access::busy, 0 );
+        ASSERT( litex.try_lock( mh ) == access::busy, 0 );
+
+        if( Synchronizer::access_traits::has_shared_access_support ) {
+            ASSERT(!litex.unlock( me ), 0);
+            memento_concurrent mh1 = access::shared();
+            ASSERT( litex.try_lock( mh ) == access::acquired, 0 );
+            ASSERT( litex.try_lock( mh1 ) == access::acquired, 0 );
+            ASSERT(!litex.unlock( mh ), 0);
+            ASSERT( litex.try_lock( me ) == access::busy, 0 );
+            ASSERT(!litex.unlock( mh1 ), 0);
+            ASSERT( litex.try_lock( me ) == access::acquired, 0 );
+        }
+        ASSERT( litex.is_locked() && litex.is_locked(access::exclusive()) && litex.is_locked(access::preserve()), 0 );
+        ASSERT(!litex.unlock( me ) && !litex.is_locked(access::exclusive()) && !litex.is_doomed(), 0);
+        if( Synchronizer::access_traits::has_multiple_owners_support ) {
+            int i; // assume, the lock can be acquired on the same memento instance
+            for(i = 0; litex.try_lock( mp1 ) == access::acquired; i++ );
+            for(int j = 0; j < 10000; j++) ASSERT( litex.try_lock( mp1 ) == access::busy, 0 ); // no exceptions
+            for(int j = 0; j < i; j++) ASSERT( !litex.unlock( mp1 ), 0 );
+        }
+        // check dooming by last owner
+        ASSERT( litex.unlock( mp ), 0);
+        ASSERT(!litex.is_locked(access::preserve()) && litex.is_doomed(), 0 );
+        //TODO: should access::serial return access::doomed on such instances?
+        ASSERT( litex.try_lock( mp ) == access::doomed, 0 );
+        ASSERT( litex.try_lock( md ) == access::doomed, 0 );
+        ASSERT( litex.try_lock( mc ) == access::doomed, 0 );
+        // resurect the instance
+        ASSERT( litex.try_lock( litex.reset( me ) ) == access::busy, 0);
+        litex.recycle();
+        ASSERT( litex.try_lock( mp ) == access::doomed, 0 );
+        ASSERT( litex.try_lock( me ) == access::doomed, 0 );
+        ASSERT( litex.try_lock( litex.reset( me ) ) == access::acquired, 0);
+        litex.init_lock( mp );
+        ASSERT( litex.is_locked(access::exclusive()) && litex.is_locked(access::preserve()), 0 );
+        ASSERT(!litex.unlock( mp ) && !litex.is_locked(access::preserve()) && !litex.is_doomed(), 0);
+        // check dooming by last lock
+        ASSERT( litex.unlock( me ), 0);
+        ASSERT( litex.is_locked(access::exclusive()) && litex.is_doomed(), 0 );
+        ASSERT( litex.try_lock( mp ) == access::doomed, 0 );
+        litex.recycle();
+        ASSERT(!litex.is_locked(access::exclusive()) && litex.is_doomed(), 0 );
+        ASSERT( litex.try_lock( me ) == access::doomed, 0 );
+    }
+
+    struct TestActor: NoAssign {
+        Synchronizer &sync;
+        int &counter;
+        atomic<int> &frags;
+        TestActor( Synchronizer &sync_, int &c, atomic<int> &f)
+            : sync(sync_), counter(c), frags(f) {}
+        /** Increments counter once for each iteration in the iteration space. */
+        void operator()( int thread ) const {
+            using tbb::access;
+            memento_concurrent mex = access::exclusive();
+            memento_preserve mp = access::preserve();
+            access::result_t r;
+            for(int i = 0; race_scheduler::next_iteration(i, thread); i++) {
+                __TBB_ASSERT_RACEPOINT(());
+                while( (r = sync.blocking_try_lock( mex )) == access::doomed ) {
+                    __TBB_ASSERT_RACEPOINT(("lock doomed"));
+                    if( (r = sync.try_lock( sync.reset( mex ) )) == access::acquired ) {
+                        frags--;
+                        break;
+                    }
+                }
+                ASSERT( r == access::acquired, 0 );
+                int c = counter;
+                race_scheduler::open_race_hole();
+                counter = c + 1;
+                __TBB_ASSERT_RACEPOINT(("lock acquired"));
+                if( sync.unlock( mex ) ) {
+                    __TBB_ASSERT_RACEPOINT(("unlock doomed"));
+                    sync.recycle();
+                    frags++;
+                }
+                if( Synchronizer::access_traits::has_multiple_owners_support ) {
+                    __TBB_ASSERT_RACEPOINT(("unlocked"));
+                    while( (r = sync.try_lock( mp )) == access::doomed ) {
+                        __TBB_ASSERT_RACEPOINT(("attach doomed"));
+                        if( (r = sync.try_lock( sync.reset( mp ) )) == access::acquired ) {
+                            frags--;
+                            break;
+                        }
+                    }
+                    ASSERT( r == access::acquired, 0 ); // it's not amount stress, must pass without access::busy
+                    __TBB_ASSERT_RACEPOINT(("attached"));
+                    ASSERT( sync.move_to( mex, mp ), 0 );
+                    int c = counter;
+                    race_scheduler::open_race_hole();
+                    counter = c - 1;
+                    __TBB_ASSERT_RACEPOINT(("locked from owner"));
+                    ASSERT( sync.move_to( mp, mex ), 0 );
+                    __TBB_ASSERT_RACEPOINT(("attached from lock"));
+                    if( sync.unlock( mp ) ) {
+                        __TBB_ASSERT_RACEPOINT(("detach doomed"));
+                        sync.recycle();
+                        frags++;
+                    }
+                } else ASSERT( false, "test is not ready for such cases");
+            }
+        }
+    };
+
+    void concurrent_correctness() {
+        aligned_space<Synchronizer, 1> sync;
+        memset(sync.begin(), 0, sizeof(sync)); // check for zerro-initialization
+        ASSERT( sync.begin()->is_doomed(), 0);
+        int counter = 0;
+        atomic<int> frags; frags = 0; // dead/live phases
+        race_scheduler::execute( 4, TestActor(*sync.begin(), counter, frags) );
+        ASSERT( !counter, "Atomicity of accesses is broken");
+        ASSERT( !frags, "Odd lifitime operation");
+        ASSERT( sync.begin()->is_doomed(), 0);
+    }
+};
+
+#if _POSIX_VERSION
+#include <signal.h>
+int main(int argc, char* argv[]) {
+    signal(SIGTSTP, reinterpret_cast<void (*)(int)>(race_scheduler::print_context));
+#else
+int main(int argc, char* argv[]) {
+#endif
+    ParseCommandLine(argc, argv);
+    SetHarnessErrorProcessing(race_scheduler::print_context);
+    set_assertion_handler(ReportError);
+#if __TBB_BTS
+    printf("Using BTS\n");
+#endif
+    test_access_tags();
+    test_synchronizer<versioned_synchronizer> versioned;
+    versioned.serial_compliance();
+    versioned.concurrent_correctness();
+    puts("done");
+}

--- a/src/proto/test_guarded.cpp
+++ b/src/proto/test_guarded.cpp
@@ -1,0 +1,213 @@
+/*
+    Copyright (C) 2005-2011, Intel Corporation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+
+
+*/
+
+#include "tbb/concurrent_vector.h"
+#include "tbb/spin_rw_mutex.h"
+#include "tbb/spin_mutex.h"
+#include "tbb/queuing_rw_mutex.h"
+#include "tbb/queuing_mutex.h"
+#include "tbb/mutex.h"
+#include "tbb/blocked_range.h"
+#include "proto/guarded.h"
+
+// Test functions definitions
+template <typename Mutextype> 
+void SimpleTypeSerialTest();
+
+template <typename Mutextype> 
+void StdStringSerialTest();
+
+void ParallelAssigmentTest(int number_of_threads);
+template <typename Mutextype> int square(tbb::guarded<int, Mutextype> n);
+
+#include <stdio.h>
+#include <string>
+#include "harness.h"
+#include "harness_assert.h"
+int main( int argc, char* argv[] ) {
+
+    MinThread = 1;
+    ParseCommandLine(argc,argv);
+    if( MinThread<1 ) {
+        printf("number of threads must be positive\n");
+        exit(1);
+    }
+    // Testing with simple type
+    SimpleTypeSerialTest<tbb::spin_mutex>();
+    SimpleTypeSerialTest<tbb::spin_rw_mutex>();
+    SimpleTypeSerialTest<tbb::queuing_mutex>();
+    SimpleTypeSerialTest<tbb::queuing_rw_mutex>();
+    SimpleTypeSerialTest<tbb::mutex>();
+
+    // Testing with std::string
+    StdStringSerialTest<tbb::spin_mutex>();
+    StdStringSerialTest<tbb::spin_rw_mutex>();
+    StdStringSerialTest<tbb::queuing_mutex>();
+    StdStringSerialTest<tbb::queuing_rw_mutex>();
+    StdStringSerialTest<tbb::mutex>();
+
+    // Parallel test
+    for( int p=MinThread; p<=MaxThread; ++p ) {
+        ParallelAssigmentTest(p);
+    }
+
+    printf ("done\n");
+    return 0;
+}
+
+//! The function tests tbb::guarded<T> with "int" type and different types of mutexes
+template <typename Mutextype> void SimpleTypeSerialTest() {
+    tbb::concurrent_vector <tbb::guarded<int, Mutextype> > intvect;
+    intvect.grow_by (10);
+
+    typedef typename tbb::guarded<int, Mutextype>::accessor int_accessor;
+    typedef typename tbb::guarded<int, Mutextype>::const_accessor int_const_accessor;
+
+    // Initializing the vector
+    for  ( int i =0; i < 10; i++) {
+        int_accessor a(intvect[i]);
+        *a = i;
+    }
+
+    {// Testing operator =, operator + with accossors
+        int_accessor a( intvect[ 0 ] );
+        int_const_accessor a1( intvect[ 1 ] );
+        int_const_accessor a2( intvect[ 2 ] );
+        *a = *a1 + *a2;
+        // The result should be 3
+        ASSERT (*a == 3, "operator + provides wrong result");
+    }
+
+    // Testing explicit acquire \ release
+    {
+        int_accessor a( intvect[ 1 ] );
+        int_const_accessor a1( intvect[ 2 ] );
+        a.release();
+        a1.release();
+        a.acquire();
+        a1.acquire();
+    }
+
+    // Testing try_acquire
+    {
+        int_accessor a( intvect[ 1 ] );
+        int_const_accessor a1( intvect[ 2 ] );
+        a.release();
+        a1.release();
+        ASSERT (a.try_acquire(), "try_acquire returned wrong value");
+        ASSERT (a1.try_acquire(), "try_acquire returned wrong value");
+    }
+
+
+    // Testing tbb::guarded<T> changing using acquire method.
+    {
+        int_accessor a( intvect[ 0 ] );
+        int_const_accessor a1( intvect[ 1 ] );
+        a.release();
+        a1.release();
+        a.acquire( intvect[ 3 ] );
+        a1.acquire( intvect[ 4 ] );
+        ASSERT (*a == 3, "Acquire(tbb::guarded<T>) method works incorrectly");
+        ASSERT (*a1 == 4, "Acquire(tbb::guarded<T>) method works incorrectly");
+    }
+
+    // Testing copy constructor for guarded<T>
+    int n = 2;
+    tbb::guarded<int, Mutextype> g_n(n);
+    ASSERT (square<Mutextype>(g_n) == 4, "Error during testing copy constructor for guarded<T>");
+
+    // Testing operator = for guarded<T>
+    tbb::guarded<int, Mutextype> n1 (1);
+    tbb::guarded<int, Mutextype> n2 (2);
+    n1 = n2;
+    int_const_accessor c_n1(n1);
+    ASSERT(*c_n1 == 2, "operator = for guarded<T> works incorrectly");
+}
+
+//! The function tests tbb::guarded<T> with "std::string" type and different types of mutexes
+template <typename Mutextype> void StdStringSerialTest() {
+    // Testing with std::string
+    tbb::concurrent_vector <tbb::guarded<std::string, Mutextype> > strvect;
+    strvect.grow_by (10);
+
+    typedef typename tbb::guarded<std::string, Mutextype>::accessor string_accessor;
+    typedef typename tbb::guarded<std::string, Mutextype>::const_accessor string_const_accessor;
+
+    // Initializing the vector
+    for  ( char i = 0; i < 10; i++) {
+        string_accessor a(strvect[i]);
+        *a = 'a' + i;
+    }
+
+    {// Testing operator =, operator +, operator != for a
+        string_accessor a( strvect[ 0 ] );
+        string_const_accessor a1( strvect[ 1 ] );
+        string_const_accessor a2( strvect[ 2 ] );
+        *a = *a1 + *a2;
+        // The result should be bc
+        ASSERT(*a == "bc", "operator + provides incorrect result for std::string type");
+    }
+
+    // Testing -> operator
+    {
+        std::string str1("abcd");
+        std::string str2("efgh");
+        tbb::guarded<std::string, Mutextype> g_str1(str1);
+        tbb::guarded<std::string, Mutextype> g_str2(str2);
+        string_accessor a( g_str1);
+        string_const_accessor a_c( g_str2 );
+
+        ASSERT (a->compare(std::string("abcd")) == 0, "Operator -> for accessor works incorrectly" );
+        ASSERT (a_c->compare(std::string("efgh")) == 0, "Operator -> for accessor works incorrectly" );
+    }
+}
+
+//! This class 
+tbb::guarded<int, tbb::spin_mutex> parallel_sum;
+class intloop {
+public:
+    intloop() {}
+    void operator () ( const tbb::blocked_range<int>& range) const {
+        for ( int i = range.begin(); i != range.end(); ++i ) {
+            tbb::guarded<int, tbb::spin_mutex>::accessor a(parallel_sum);
+            *a = *a + 1;
+        }
+    }
+};
+
+//! Performs an addition from 0 to 1000 in a loop
+void ParallelAssigmentTest(int number_of_threads) {
+    {
+        tbb::guarded<int, tbb::spin_mutex>::accessor a(parallel_sum);
+        *a = 0;
+    }
+
+    intloop loop;
+    NativeParallelFor(tbb::blocked_range<int>(0, 1000, 1000 / number_of_threads), loop);
+
+    tbb::guarded<int, tbb::spin_mutex>::const_accessor c_a(parallel_sum);
+    ASSERT(*c_a == 1000, "tbb::guarded doesn't work properly in parallel mode");
+}
+
+template <typename Mutextype> int square(tbb::guarded<int, Mutextype> n) {
+    typedef typename tbb::guarded<int, Mutextype>::accessor int_accessor;
+    int_accessor a(n);
+    return (*a) * (*a);
+}


### PR DESCRIPTION
Includes:
* "Litex" (versioned_synchronizer), implementing SeqLock implementation joint with life-time cycle management, see https://software.intel.com/en-us/blogs/2011/01/26/joint-lifetime-and-access-synchronization-algorithm-for-shared-dynamic-objects
* detached accessor prototypes (later & independently Anthony Williams publicized it as well)
* simple standalone testing mechanism, which amplifies windows for the race conditions and enables simple reproduction by reporting race-point sequence codes

The first revision is published with minimal changes and thus not modernized and not guaranteed to compile with the latest TBB.

Published for sake of BlazingPhoenix/concurrent-hash-map#1 implementing C++ standard proposal P0652